### PR TITLE
ghdl: support aarch64

### DIFF
--- a/.github/workflows/get_all_packages.py
+++ b/.github/workflows/get_all_packages.py
@@ -2,6 +2,7 @@ import sys
 import json
 import subprocess
 
+
 def run(purpose, *args):
     process = subprocess.Popen(
         [*args],
@@ -16,6 +17,7 @@ def run(purpose, *args):
         exit(-1)
     return process.stdout
 
+
 flake_meta = json.load(run("get flake metadata", "nix", "flake", "show", "--json"))
 packages = flake_meta["packages"]
 for platform, packages in packages.items():
@@ -24,10 +26,15 @@ for platform, packages in packages.items():
             continue
         tgt = f".#packages.{platform}.{package}"
         outputs = []
-        drv = json.load(run(f"get derivation info for {package}", "nix", "derivation", "show", tgt))
+        drv = json.load(
+            run(f"get derivation info for {package}", "nix", "derivation", "show", tgt)
+        )
         keys = list(drv.keys())
         if len(keys) != 1:
-            print(f"'nix derivation show' unexpectedly returned {len(keys)} paths, expected exactly 1: {tgt}", file=sys.stderr)
+            print(
+                f"'nix derivation show' unexpectedly returned {len(keys)} paths, expected exactly 1: {tgt}",
+                file=sys.stderr,
+            )
             exit(-1)
         output_list = drv[keys[0]]["outputs"]
         for output in output_list:

--- a/nix/ghdl-bin.nix
+++ b/nix/ghdl-bin.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  system,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  patchelfUnstable,
+  insert-dylib,
+  darwin,
+  zlib,
+  python3,
+  data ? (builtins.fromTOML (builtins.readFile ./ghdl-bin.toml)),
+}: let
+  version = data.version;
+  system-data = data."${system}";
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "ghdl-bin";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://github.com/ghdl/ghdl/releases/download/v${finalAttrs.version}/ghdl-${system-data.backend}-${finalAttrs.version}-${system-data.platform_double}.tar.gz";
+      inherit (system-data) sha256;
+    };
+
+    buildInputs = [
+      zlib
+    ];
+
+    nativeBuildInputs =
+      lib.optionals (!stdenv.hostPlatform.isDarwin) [
+        autoPatchelfHook
+        patchelfUnstable
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+        (python3.withPackages (ps: with ps; [lief click]))
+        darwin.autoSignDarwinBinariesHook
+      ];
+
+    buildPhase = "true";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r bin $out/bin
+      cp -r include $out/include
+      cp -r lib $out/lib
+      runHook postInstall
+    '';
+
+    fixupPhase =
+      lib.optionalString (!stdenv.isDarwin) "exit -1" # TODO
+      + lib.optionalString (stdenv.isDarwin) ''
+        runHook preFixup
+        install_name_tool \
+          -change /usr/lib/libc++.1.dylib ${stdenv.cc.libcxx}/lib/libc++.1.dylib \
+          -change /usr/lib/libz.1.dylib ${zlib}/lib/libz.1.dylib \
+          $out/bin/ghdl1-llvm
+        clang \
+          -x c\
+          -dynamiclib \
+          -D GHDL_PREFIX=\"$out/lib/ghdl\" \
+          -o $out/lib/set_ghdl_pfx.dylib \
+          -install_name $out/lib/set_ghdl_pfx.dylib \
+          - <<'EOF'
+          #include <stdlib.h>
+
+          __attribute__((constructor))
+          static void set_ghdl_pfx(void) {
+              if (!getenv("GHDL_PREFIX")) {
+                  setenv("GHDL_PREFIX", GHDL_PREFIX, 1);
+              }
+          }
+        EOF
+        python3 ${./supporting/lief_inject_dylib.py} \
+          --inject $out/lib/set_ghdl_pfx.dylib \
+          --inplace $out/lib/libghdl-*.dylib
+        runHook postFixup
+      '';
+
+    meta = {
+      description = "VHDL 2008/93/87 simulator";
+      homepage = "https://github.com/ghdl/ghdl";
+      license = lib.licenses.gpl2Plus;
+      platforms = lib.lists.remove "version" (builtins.attrNames data);
+      broken = !stdenv.isDarwin;
+    };
+  })

--- a/nix/ghdl-bin.toml
+++ b/nix/ghdl-bin.toml
@@ -1,0 +1,11 @@
+version = "5.0.1"
+
+[x86_64-darwin]
+backend = "llvm"
+platform_double = "macos13-x86_64"
+sha256 = "sha256-F29YhXysqAOSFfnq08krXOBVigQ0FSlXyishnVuWZEM="
+
+[aarch64-darwin]
+backend = "llvm"
+platform_double = "macos14-aarch64"
+sha256 = "sha256-R+nLj50zBumolpcbKgrO8Td25bmNcXRaLmHVcy1eyWQ="

--- a/nix/supporting/download_github_snapshot.py
+++ b/nix/supporting/download_github_snapshot.py
@@ -2,10 +2,10 @@
 # Adapted from OpenLane Build Scripts
 #
 # https://github.com/The-OpenROAD-Project/OpenLane/blob/3c41826a8aaaf724e423593ddc7bea392e65277e/docker/utils.py
-# 
+#
 # and Volare
 #
-# 
+#
 #
 # Copyright 2021 Efabless Corporation
 #
@@ -41,7 +41,8 @@ except ImportError:
         file=sys.stderr,
     )
     exit(-1)
-    
+
+
 class GitHubSession(httpx.Client):
     def __init__(
         self,
@@ -88,9 +89,11 @@ class GitHubSession(httpx.Client):
     @classmethod
     def get_user_agent(Self) -> str:
         return f"nix-eda"
-    
+
+
 github_client = GitHubSession()
 download_cache = {}
+
 
 def download_tarball(repo_url: str, commit: str) -> str:
     repo_path = urllib.parse.urlsplit(repo_url).path.strip("/")
@@ -237,13 +240,16 @@ def main(repo_url, commit, out_dir, filter):
     """
     Downloads a snapshot of a GitHub repo, i.e. with all GitHub-based submodules
     recursively downloaded.
-    
+
     Currently does not work for repositories with private or externally hosted
     submodules.
     """
     global github_client
     fetch_tarball_and_submodules(
-        repo_url=repo_url, commit=commit, base_path=out_dir, filter=filter,
+        repo_url=repo_url,
+        commit=commit,
+        base_path=out_dir,
+        filter=filter,
     )
 
 

--- a/nix/supporting/lief_inject_dylib.py
+++ b/nix/supporting/lief_inject_dylib.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Uses the lief library to inject a dylib
+"""
+import os
+import lief
+import click
+
+
+@click.command()
+@click.option("-o", "--dylib-out", type=click.Path(writable=True), required=False)
+@click.option("-i", "--inplace", is_flag=True)
+@click.option("--inject", type=click.Path(readable=True), required=True)
+@click.argument("dylib_in")
+@click.pass_context
+def main(ctx, dylib_out, inplace, inject, dylib_in):
+    universal = lief.MachO.parse(dylib_in)
+    if universal is None:
+        ctx.exit(-1)
+
+    inject = os.path.abspath(inject)
+
+    if inplace:
+        dylib_out = dylib_in
+
+    arch_found = False
+    for arch in universal:
+        if arch_found:
+            ctx.fail("lief_inject_dylib.py doesn't support multi-arch binaries")
+            ctx.exit(-1)
+        arch_found = True
+        arch.add_library(os.path.abspath(inject))
+
+        if arch.has_code_signature:
+            arch.remove_signature()
+
+    print(f"Writing to '{dylib_out}'…")
+    universal.write(dylib_out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds ghdl support for aarch64 platforms via two approaches:

- Adds the first binary package to nix-eda, `ghdl-bin`, for both Darwin platforms, patching the pre-built binaries to work in a Nix environment.
- Switches to `ghdl-llvm` for all platforms not supported by `ghdl-bin`, as `ghdl-mcode` did not support `aarch64-linux`.
- Adds a small test suite to yosys-ghdl to make sure it works.

---

P.S.: The patching code is one of the silliest things I've ever written. I'm surprised it worked.