### PR TITLE
repo-wide: relicense under MIT, nixfmt-tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
               archs: "aarch64",
             },
             {
-              name: "macOS 13",
+              name: "macOS 15",
               family: "macos",
-              runner: "macos-13",
+              runner: "macos-15-intel",
               archs: "x86_64",
             },
             {
-              name: "macOS 14",
+              name: "macOS 15",
               family: "macos",
-              runner: "macos-14",
+              runner: "macos-15",
               archs: "arm64",
             },
           ]

--- a/Authors.md
+++ b/Authors.md
@@ -9,8 +9,8 @@ alphabetical order):
 > https://github.com/fossi-foundation/nix-eda/graphs/contributors for a full list
 > of human contributors.
 
-* Efabless Corporation \<https://efabless.com\>
-  (via https://github.com/efabless/nix-eda)
+* UmbraLogic Technologies LLC \<https://chipfoundry.io>
+  * As owner of Efabless Corporation IP
 * Leo Moser \<leo.moser@pm.me\>
 * Mohamed Gaber \<<me@donn.website>\>
 
@@ -18,3 +18,5 @@ alphabetical order):
 
 * Phillip Wagner \<philipp@fossi-foundation.org\> - for help setting up the
   Nix Cache
+* Jeffrey DiCorpo \<jeffdi@chipfoundry.io\> - for agreeing to relicense under
+  the MIT license so we would be able to upstream.

--- a/Contributing.md
+++ b/Contributing.md
@@ -7,10 +7,9 @@ Please build tools on at least x86_64-linux before submitting them.
 
 The CI will attempt to build them for the other three platforms: x86_64-darwin,
 aarch64-linux and aarch64-darwin, but if you have the capacity to test those
-builds yourselves, it will greatly speed up the PR
-process.
+builds yourselves, it will greatly speed up the PR process.
 
-Nix code must be formatted using `alejandra`: `nix fmt .`
+Nix code must be formatted using `nixfmt-tree`: just run `nix fmt .`
 
 ## Submissions
 Make your changes and then submit them as a pull requests to the `main` branch.
@@ -20,10 +19,16 @@ more information on using pull requests.
 
 ## Licensing and Copyright
 
-Please add your name and email (and/or employer) to [Authors.md](./Authors.md).
+Please note all code contributions must have the same license as nix-eda, i.e.,
+the standard MIT license as published by the Open-Source Initiative (OSI.)
 
-We request that your changes be under the ISC/MIT License. 
+You, as the submitter of the patch, are responsible for your patch, regardless\
+of where that change came from; whether you:
 
-We intend to eventually, when all Efabless Code is rewritten, relicense this
-project under the ISC/MIT License in the hopes of upstreaming at least some of
-these derivations to nixpkgs proper.
+1. Wrote it yourself and are willing to release your changes under said license.
+2. Acquired it from other libre software with compatible license terms
+   (and of course the requisite copyright notices.)
+3. Created using coding assistants, "Generative AI" software, or similar tools.
+
+For significant changes, please add either your or your employer's information
+to [Authors.md](./Authors.md).

--- a/License
+++ b/License
@@ -1,202 +1,22 @@
+MIT License
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2025 fossi-foundation/nix-eda Contributors
+Copyright (c) 2024-2025 UmbraLogic Technologies LLC
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-   1. Definitions.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Readme.md
+++ b/Readme.md
@@ -70,33 +70,35 @@ nix shell github:fossi-foundation/nix-eda#{magic,xschem}
 
 See [docs/flake_api.md](./docs/flake_api.md).
 
-## ⚖️ License
+## ⚖️ License and Legal
 
-The combined work is available under the Apache License, version 2.0.
-See 'License'. See [Authors.md](./Authors.md) for a list of authors and
-copyright holders.
-
-We are eventually planning to relicense under the MIT License (to be compatible
-with nixpkgs upstream) and we kindly ask all new contributions to be under said
-license.
+nix-eda is available under the MIT license. See 'License'.
 
 Binary cache is hosted by the FOSSi Foundation.
 
-nix-eda is based on [nix-eda](https://github.com/efabless/nix-eda)
-by Efabless Corporation:
+nix-eda is based on [nix-eda](https://github.com/efabless/nix-eda) by Efabless
+Corporation, whose assets are currently owned by UmbraLogic Technologies LLC.
+UmbraLogic has agreed to relicense all code under the MIT license to be
+compatible with upstream nixpkgs, for which we are grateful.
 
 ```
-Copyright 2024 Efabless Corporation
+Copyright (c) 2025 UmbraLogic Technologies LLC:
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-     http://www.apache.org/licenses/LICENSE-2.0
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ``` 

--- a/docs/flake-template.nix
+++ b/docs/flake-template.nix
@@ -8,72 +8,88 @@
 
     # To depend on another nix-eda-based flake:
     /*
-       librelane = {
-      url = "github:librelane/librelane";
-      inputs.nix-eda.follows = "nix-eda";
-    };
+         librelane = {
+        url = "github:librelane/librelane";
+        inputs.nix-eda.follows = "nix-eda";
+      };
     */
 
     # To depend on another nixpkgs-based flake:
     /*
-       devshell = {
-      url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "nix-eda/nixpkgs";
-    };
+         devshell = {
+        url = "github:numtide/devshell";
+        inputs.nixpkgs.follows = "nix-eda/nixpkgs";
+      };
     */
   };
 
-  outputs = {
-    self,
-    nix-eda,
-    # don't forget to expose other inputs here if applicable…
-    ...
-  }: let
-    nixpkgs = nix-eda.inputs.nixpkgs;
-    lib = nixpkgs.lib;
-  in {
-    overlays = {
-      default = lib.composeManyExtensions [
-        (pkgs': pkgs: let
-          callPackage = lib.callPackageWith pkgs';
-        in {
-          # Add binary derivations here
-        })
-        (
-          nix-eda.composePythonOverlay (pkgs': pkgs: pypkgs': pypkgs: let
-            callPythonPackage = lib.callPackageWith (pkgs' // pypkgs');
-          in {
-            # Add python package derivations here
-          })
-        )
-      ];
-    };
+  outputs =
+    {
+      self,
+      nix-eda,
+      # don't forget to expose other inputs here if applicable…
+      ...
+    }:
+    let
+      nixpkgs = nix-eda.inputs.nixpkgs;
+      lib = nixpkgs.lib;
+    in
+    {
+      overlays = {
+        default = lib.composeManyExtensions [
+          (
+            pkgs': pkgs:
+            let
+              callPackage = lib.callPackageWith pkgs';
+            in
+            {
+              # Add binary derivations here
+            }
+          )
+          (nix-eda.composePythonOverlay (
+            pkgs': pkgs: pypkgs': pypkgs:
+            let
+              callPythonPackage = lib.callPackageWith (pkgs' // pypkgs');
+            in
+            {
+              # Add python package derivations here
+            }
+          ))
+        ];
+      };
 
-    legacyPackages = nix-eda.forAllSystems (
-      system:
+      legacyPackages = nix-eda.forAllSystems (
+        system:
         import nix-eda.inputs.nixpkgs {
           inherit system;
-          overlays = [nix-eda.overlays.default self.overlays.default];
+          overlays = [
+            nix-eda.overlays.default
+            self.overlays.default
+          ];
         }
-    );
+      );
 
-    packages = nix-eda.forAllSystems (
-      system: let
-        pkgs = self.legacyPackages."${system}";
-      in {
-        # To be flakes-compatible, you also need to expose packages as follows:
-        #   inherit (pkgs) mypackage;
-        # And optionally, set a default package as well:
-        #   default = pkgs.mypackage;
-      }
-    );
+      packages = nix-eda.forAllSystems (
+        system:
+        let
+          pkgs = self.legacyPackages."${system}";
+        in
+        {
+          # To be flakes-compatible, you also need to expose packages as follows:
+          #   inherit (pkgs) mypackage;
+          # And optionally, set a default package as well:
+          #   default = pkgs.mypackage;
+        }
+      );
 
-    devShells = nix-eda.forAllSystems (
-      system: let
-        pkgs = self.legacyPackages."${system}";
-        callPackage = lib.callPackageWith pkgs;
-      in {
-      }
-    );
-  };
+      devShells = nix-eda.forAllSystems (
+        system:
+        let
+          pkgs = self.legacyPackages."${system}";
+          callPackage = lib.callPackageWith pkgs;
+        in
+        {
+        }
+      );
+    };
 }

--- a/nix/bitwuzla.nix
+++ b/nix/bitwuzla.nix
@@ -1,18 +1,6 @@
-# Copyright 2023 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# Code adapated from Nixpkgs, original license follows:
-# ---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 # Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -25,6 +13,7 @@
 #
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -66,40 +55,41 @@ stdenv.mkDerivation (self: {
     inherit sha256;
   };
 
-  nativeBuildInputs = [cmake pkg-config];
-  buildInputs =
-    [
-      cadical
-      cryptominisat
-      picosat
-      minisat
-      btor2tools
-      symfpu
-      gmp
-      zlib
-    ]
-    ++ lib.optional withLingeling lingeling;
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    cadical
+    cryptominisat
+    picosat
+    minisat
+    btor2tools
+    symfpu
+    gmp
+    zlib
+  ] ++ lib.optional withLingeling lingeling;
 
-  cmakeFlags =
-    [
-      "-DBUILD_SHARED_LIBS=ON"
-      "-DPicoSAT_INCLUDE_DIR=${lib.getDev picosat}/include/picosat"
-      "-DBtor2Tools_INCLUDE_DIR=${lib.getDev btor2tools}/include/btor2parser"
-      "-DBtor2Tools_LIBRARIES=${lib.getLib btor2tools}/lib/libbtor2parser${stdenv.hostPlatform.extensions.sharedLibrary}"
-    ]
-    ++ lib.optional self.doCheck "-DTESTING=YES";
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DPicoSAT_INCLUDE_DIR=${lib.getDev picosat}/include/picosat"
+    "-DBtor2Tools_INCLUDE_DIR=${lib.getDev btor2tools}/include/btor2parser"
+    "-DBtor2Tools_LIBRARIES=${lib.getLib btor2tools}/lib/libbtor2parser${stdenv.hostPlatform.extensions.sharedLibrary}"
+  ] ++ lib.optional self.doCheck "-DTESTING=YES";
 
-  checkInputs = [python3 gtest];
+  checkInputs = [
+    python3
+    gtest
+  ];
   doCheck = false; # they take freaking forever
-  preCheck = let
-    var =
-      if stdenv.isDarwin
-      then "DYLD_LIBRARY_PATH"
-      else "LD_LIBRARY_PATH";
-  in ''
-    export ${var}=$(readlink -f lib)
-    patchShebangs ..
-  '';
+  preCheck =
+    let
+      var = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+    in
+    ''
+      export ${var}=$(readlink -f lib)
+      patchShebangs ..
+    '';
 
   meta = {
     description = "A SMT solver for fixed-size bit-vectors, floating-point arithmetic, arrays, and uninterpreted functions";

--- a/nix/cocotb.nix
+++ b/nix/cocotb.nix
@@ -1,7 +1,5 @@
-# Copyright (c) 2025 nix-eda Contributors
-#
-# Adapted from nixpkgs
-#
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
 # Copyright (c) 2003-2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -38,7 +36,8 @@
   # Metadata
   version ? "2.0.0",
   sha256 ? "sha256-BpshczKA83ZeytGDrHEg6IAbI5FxciAUnzwE10hgPC0=",
-}: let
+}:
+let
   self = buildPythonPackage {
     pname = "cocotb";
     inherit version;
@@ -52,8 +51,11 @@
       inherit sha256;
     };
 
-    buildInputs = [setuptools zlib];
-    propagatedBuildInputs = [find-libpython];
+    buildInputs = [
+      setuptools
+      zlib
+    ];
+    propagatedBuildInputs = [ find-libpython ];
 
     postPatch = ''
       patchShebangs bin/*.py
@@ -67,7 +69,7 @@
       ghdl
     ];
 
-    pythonImportsCheck = ["cocotb"];
+    pythonImportsCheck = [ "cocotb" ];
 
     meta = {
       changelog = "https://github.com/cocotb/cocotb/releases/tag/v${version}";
@@ -79,4 +81,4 @@
     };
   };
 in
-  self
+self

--- a/nix/create-docker.nix
+++ b/nix/create-docker.nix
@@ -1,22 +1,6 @@
-# Copyright 2024 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ---
-# This file is a modified version of
-# https://raw.githubusercontent.com/NixOS/nix/master/docker.nix that exposes
-# more options for the final image and enables the use of sudo.
-# Original license follows:
-#
+# SPDX-License-Identifier: LGPL-2.0-or-later
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 # Copyright (C) 2012-2017 Eelco Dolstra and the Nix Contributors
 #
 # This library is free software; you can redistribute it and/or
@@ -32,27 +16,33 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# This file is a modified version of
+# https://raw.githubusercontent.com/NixOS/nix/master/docker.nix that exposes
+# more options for the final image and enables the use of sudo.
 {
-  pkgs ? import <nixpkgs> {},
+  pkgs ? import <nixpkgs> { },
   lib ? pkgs.lib,
   name ? "nix",
   tag ? "latest",
   bundleNixpkgs ? true,
   channelName ? "nixpkgs",
   channelURL ? "https://nixos.org/channels/nixpkgs-unstable",
-  extraPkgs ? [],
+  extraPkgs ? [ ],
   maxLayers ? 100,
-  nixConf ? {},
+  nixConf ? { },
   flake-registry ? null,
   # ADDED
   image-created ? null,
   image-extraCommands ? "",
   image-config-cwd ? null,
-  image-config-cmd ? ["/root/.nix-profile/bin/bash"],
-  image-config-extra-path ? [],
-  image-config-extra-env ? [],
-}: let
-  defaultPkgs = with pkgs;
+  image-config-cmd ? [ "/root/.nix-profile/bin/bash" ],
+  image-config-extra-path ? [ ],
+  image-config-extra-env ? [ ],
+}:
+let
+  defaultPkgs =
+    with pkgs;
     [
       nix
       bashInteractive
@@ -82,7 +72,7 @@
         shell = "${pkgs.bashInteractive}/bin/bash";
         home = "/root";
         gid = 0;
-        groups = ["root"];
+        groups = [ "root" ];
         description = "System administrator";
       };
 
@@ -91,39 +81,31 @@
         shell = "${pkgs.shadow}/bin/nologin";
         home = "/var/empty";
         gid = 65534;
-        groups = ["nobody"];
+        groups = [ "nobody" ];
         description = "Unprivileged account (don't use!)";
       };
     }
     // lib.listToAttrs (
-      map
-      (
-        n: {
-          name = "nixbld${toString n}";
-          value = {
-            uid = 30000 + n;
-            gid = 30000;
-            groups = ["nixbld"];
-            description = "Nix build user ${toString n}";
-          };
-        }
-      )
-      (lib.lists.range 1 32)
+      map (n: {
+        name = "nixbld${toString n}";
+        value = {
+          uid = 30000 + n;
+          gid = 30000;
+          groups = [ "nixbld" ];
+          description = "Nix build user ${toString n}";
+        };
+      }) (lib.lists.range 1 32)
     )
     // lib.listToAttrs (
-      map
-      (
-        n: {
-          name = "user-${toString n}";
-          value = {
-            uid = n;
-            gid = 0;
-            groups = ["root"];
-            description = "user account";
-          };
-        }
-      )
-      (lib.lists.range 1 29999)
+      map (n: {
+        name = "user-${toString n}";
+        value = {
+          uid = n;
+          gid = 0;
+          groups = [ "root" ];
+          description = "user account";
+        };
+      }) (lib.lists.range 1 29999)
     );
 
   groups = {
@@ -133,25 +115,21 @@
   };
 
   userToPasswd = (
-    k: {
+    k:
+    {
       uid,
       gid ? 65534,
       home ? "/var/empty",
       description ? "",
       shell ? "/bin/false",
-      groups ? [],
-    }: "${k}:x:${toString uid}:${toString gid}:${description}:${home}:${shell}"
+      groups ? [ ],
+    }:
+    "${k}:x:${toString uid}:${toString gid}:${description}:${home}:${shell}"
   );
-  passwdContents = (
-    lib.concatStringsSep "\n"
-    (lib.attrValues (lib.mapAttrs userToPasswd users))
-  );
+  passwdContents = (lib.concatStringsSep "\n" (lib.attrValues (lib.mapAttrs userToPasswd users)));
 
-  userToShadow = k: {...}: "${k}:!:1::::::";
-  shadowContents = (
-    lib.concatStringsSep "\n"
-    (lib.attrValues (lib.mapAttrs userToShadow users))
-  );
+  userToShadow = k: { ... }: "${k}:!:1::::::";
+  shadowContents = (lib.concatStringsSep "\n" (lib.attrValues (lib.mapAttrs userToShadow users)));
 
   # Map groups to members
   # {
@@ -161,190 +139,204 @@
     let
       # Create a flat list of user/group mappings
       mappings = (
-        builtins.foldl'
-        (
-          acc: user: let
-            groups = users.${user}.groups or [];
+        builtins.foldl' (
+          acc: user:
+          let
+            groups = users.${user}.groups or [ ];
           in
-            acc
-            ++ map
-            (group: {
-              inherit user group;
-            })
-            groups
-        )
-        []
-        (lib.attrNames users)
-      );
-    in (
-      builtins.foldl'
-      (
-        acc: v:
           acc
-          // {
-            ${v.group} = acc.${v.group} or [] ++ [v.user];
-          }
-      )
-      {}
-      mappings
-    )
+          ++ map (group: {
+            inherit user group;
+          }) groups
+        ) [ ] (lib.attrNames users)
+      );
+    in
+    (builtins.foldl' (
+      acc: v:
+      acc
+      // {
+        ${v.group} = acc.${v.group} or [ ] ++ [ v.user ];
+      }
+    ) { } mappings)
   );
 
-  groupToGroup = k: {gid}: let
-    members = groupMemberMap.${k} or [];
-  in "${k}:x:${toString gid}:${lib.concatStringsSep "," members}";
-  groupContents = (
-    lib.concatStringsSep "\n"
-    (lib.attrValues (lib.mapAttrs groupToGroup groups))
-  );
+  groupToGroup =
+    k:
+    { gid }:
+    let
+      members = groupMemberMap.${k} or [ ];
+    in
+    "${k}:x:${toString gid}:${lib.concatStringsSep "," members}";
+  groupContents = (lib.concatStringsSep "\n" (lib.attrValues (lib.mapAttrs groupToGroup groups)));
 
   defaultNixConf = {
     sandbox = "false";
     build-users-group = "nixbld";
-    trusted-public-keys = ["cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="];
+    trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" ];
   };
 
   nixConfContents =
-    (lib.concatStringsSep "\n" (lib.mapAttrsFlatten (n: v: let
-      vStr =
-        if builtins.isList v
-        then lib.concatStringsSep " " v
-        else v;
-    in "${n} = ${vStr}") (defaultNixConf // nixConf)))
+    (lib.concatStringsSep "\n" (
+      lib.mapAttrsFlatten (
+        n: v:
+        let
+          vStr = if builtins.isList v then lib.concatStringsSep " " v else v;
+        in
+        "${n} = ${vStr}"
+      ) (defaultNixConf // nixConf)
+    ))
     + "\n";
 
-  baseSystem = let
-    nixpkgs = pkgs.path;
-    channel = pkgs.runCommand "channel-nixos" {inherit bundleNixpkgs;} ''
-      mkdir $out
-      if [ "$bundleNixpkgs" ]; then
-        ln -s ${nixpkgs} $out/nixpkgs
-        echo "[]" > $out/manifest.nix
-      fi
-    '';
-    rootEnv = pkgs.buildPackages.buildEnv {
-      name = "root-profile-env";
-      paths = defaultPkgs;
-    };
-    manifest = pkgs.buildPackages.runCommand "manifest.nix" {} ''
-      cat > $out <<EOF
-      [
-      ${lib.concatStringsSep "\n" (builtins.map (drv: let
-          outputs = drv.outputsToInstall or ["out"];
-        in ''
-          {
-            ${lib.concatStringsSep "\n" (builtins.map (output: ''
-              ${output} = { outPath = "${lib.getOutput output drv}"; };
-            '')
-            outputs)}
-            outputs = [ ${lib.concatStringsSep " " (builtins.map (x: "\"${x}\"") outputs)} ];
-            name = "${drv.name}";
-            outPath = "${drv}";
-            system = "${drv.system}";
-            type = "derivation";
-            meta = { };
-          }
-        '')
-        defaultPkgs)}
-      ]
-      EOF
-    '';
-    profile = pkgs.buildPackages.runCommand "user-environment" {} ''
-      mkdir $out
-      cp -a ${rootEnv}/* $out/
-      ln -s ${manifest} $out/manifest.nix
-    '';
-    flake-registry-path =
-      if (flake-registry == null)
-      then null
-      else if (builtins.readFileType (toString flake-registry)) == "directory"
-      then "${flake-registry}/flake-registry.json"
-      else flake-registry;
-  in
+  baseSystem =
+    let
+      nixpkgs = pkgs.path;
+      channel = pkgs.runCommand "channel-nixos" { inherit bundleNixpkgs; } ''
+        mkdir $out
+        if [ "$bundleNixpkgs" ]; then
+          ln -s ${nixpkgs} $out/nixpkgs
+          echo "[]" > $out/manifest.nix
+        fi
+      '';
+      rootEnv = pkgs.buildPackages.buildEnv {
+        name = "root-profile-env";
+        paths = defaultPkgs;
+      };
+      manifest = pkgs.buildPackages.runCommand "manifest.nix" { } ''
+        cat > $out <<EOF
+        [
+        ${lib.concatStringsSep "\n" (
+          builtins.map (
+            drv:
+            let
+              outputs = drv.outputsToInstall or [ "out" ];
+            in
+            ''
+              {
+                ${lib.concatStringsSep "\n" (
+                  builtins.map (output: ''
+                    ${output} = { outPath = "${lib.getOutput output drv}"; };
+                  '') outputs
+                )}
+                outputs = [ ${lib.concatStringsSep " " (builtins.map (x: "\"${x}\"") outputs)} ];
+                name = "${drv.name}";
+                outPath = "${drv}";
+                system = "${drv.system}";
+                type = "derivation";
+                meta = { };
+              }
+            ''
+          ) defaultPkgs
+        )}
+        ]
+        EOF
+      '';
+      profile = pkgs.buildPackages.runCommand "user-environment" { } ''
+        mkdir $out
+        cp -a ${rootEnv}/* $out/
+        ln -s ${manifest} $out/manifest.nix
+      '';
+      flake-registry-path =
+        if (flake-registry == null) then
+          null
+        else if (builtins.readFileType (toString flake-registry)) == "directory" then
+          "${flake-registry}/flake-registry.json"
+        else
+          flake-registry;
+    in
     pkgs.runCommand "base-system"
-    {
-      inherit passwdContents groupContents shadowContents nixConfContents;
-      passAsFile = [
-        "passwdContents"
-        "groupContents"
-        "shadowContents"
-        "nixConfContents"
-      ];
-      allowSubstitutes = false;
-      preferLocalBuild = true;
-    } (''
-        env
-        set -x
-        mkdir -p $out/etc
+      {
+        inherit
+          passwdContents
+          groupContents
+          shadowContents
+          nixConfContents
+          ;
+        passAsFile = [
+          "passwdContents"
+          "groupContents"
+          "shadowContents"
+          "nixConfContents"
+        ];
+        allowSubstitutes = false;
+        preferLocalBuild = true;
+      }
+      (
+        ''
+          env
+          set -x
+          mkdir -p $out/etc
 
-        mkdir -p $out/etc/ssl/certs
-        ln -s /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt $out/etc/ssl/certs
+          mkdir -p $out/etc/ssl/certs
+          ln -s /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt $out/etc/ssl/certs
 
-        cat $passwdContentsPath > $out/etc/passwd
-        echo "" >> $out/etc/passwd
+          cat $passwdContentsPath > $out/etc/passwd
+          echo "" >> $out/etc/passwd
 
-        cat $groupContentsPath > $out/etc/group
-        echo "" >> $out/etc/group
+          cat $groupContentsPath > $out/etc/group
+          echo "" >> $out/etc/group
 
-        cat $shadowContentsPath > $out/etc/shadow
-        echo "" >> $out/etc/shadow
+          cat $shadowContentsPath > $out/etc/shadow
+          echo "" >> $out/etc/shadow
 
-        mkdir -p $out/usr
-        ln -s /nix/var/nix/profiles/share $out/usr/
+          mkdir -p $out/usr
+          ln -s /nix/var/nix/profiles/share $out/usr/
 
-        mkdir -p $out/nix/var/nix/gcroots
+          mkdir -p $out/nix/var/nix/gcroots
 
-        mkdir $out/tmp
+          mkdir $out/tmp
 
-        mkdir -p $out/var/tmp
+          mkdir -p $out/var/tmp
 
-        mkdir -p $out/etc/nix
-        cat $nixConfContentsPath > $out/etc/nix/nix.conf
+          mkdir -p $out/etc/nix
+          cat $nixConfContentsPath > $out/etc/nix/nix.conf
 
-        mkdir -p $out/root
-        mkdir -p $out/nix/var/nix/profiles/per-user/root
+          mkdir -p $out/root
+          mkdir -p $out/nix/var/nix/profiles/per-user/root
 
-        ln -s ${profile} $out/nix/var/nix/profiles/default-1-link
-        ln -s $out/nix/var/nix/profiles/default-1-link $out/nix/var/nix/profiles/default
-        ln -s /nix/var/nix/profiles/default $out/root/.nix-profile
+          ln -s ${profile} $out/nix/var/nix/profiles/default-1-link
+          ln -s $out/nix/var/nix/profiles/default-1-link $out/nix/var/nix/profiles/default
+          ln -s /nix/var/nix/profiles/default $out/root/.nix-profile
 
-        ln -s ${channel} $out/nix/var/nix/profiles/per-user/root/channels-1-link
-        ln -s $out/nix/var/nix/profiles/per-user/root/channels-1-link $out/nix/var/nix/profiles/per-user/root/channels
+          ln -s ${channel} $out/nix/var/nix/profiles/per-user/root/channels-1-link
+          ln -s $out/nix/var/nix/profiles/per-user/root/channels-1-link $out/nix/var/nix/profiles/per-user/root/channels
 
-        mkdir -p $out/root/.nix-defexpr
-        ln -s $out/nix/var/nix/profiles/per-user/root/channels $out/root/.nix-defexpr/channels
-        echo "${channelURL} ${channelName}" > $out/root/.nix-channels
+          mkdir -p $out/root/.nix-defexpr
+          ln -s $out/nix/var/nix/profiles/per-user/root/channels $out/root/.nix-defexpr/channels
+          echo "${channelURL} ${channelName}" > $out/root/.nix-channels
 
-        mkdir -p $out/bin $out/usr/bin
-        ln -s ${pkgs.coreutils}/bin/env $out/usr/bin/env
-        ln -s ${pkgs.bashInteractive}/bin/bash $out/bin/sh
+          mkdir -p $out/bin $out/usr/bin
+          ln -s ${pkgs.coreutils}/bin/env $out/usr/bin/env
+          ln -s ${pkgs.bashInteractive}/bin/bash $out/bin/sh
 
-      ''
-      + (lib.optionalString (flake-registry-path != null) ''
-        nixCacheDir="/root/.cache/nix"
-        mkdir -p $out$nixCacheDir
-        globalFlakeRegistryPath="$nixCacheDir/flake-registry.json"
-        ln -s ${flake-registry-path} $out$globalFlakeRegistryPath
-        mkdir -p $out/nix/var/nix/gcroots/auto
-        rootName=$(${pkgs.nix}/bin/nix --extra-experimental-features nix-command hash file --type sha1 --base32 <(echo -n $globalFlakeRegistryPath))
-        ln -s $globalFlakeRegistryPath $out/nix/var/nix/gcroots/auto/$rootName
-      ''));
+        ''
+        + (lib.optionalString (flake-registry-path != null) ''
+          nixCacheDir="/root/.cache/nix"
+          mkdir -p $out$nixCacheDir
+          globalFlakeRegistryPath="$nixCacheDir/flake-registry.json"
+          ln -s ${flake-registry-path} $out$globalFlakeRegistryPath
+          mkdir -p $out/nix/var/nix/gcroots/auto
+          rootName=$(${pkgs.nix}/bin/nix --extra-experimental-features nix-command hash file --type sha1 --base32 <(echo -n $globalFlakeRegistryPath))
+          ln -s $globalFlakeRegistryPath $out/nix/var/nix/gcroots/auto/$rootName
+        '')
+      );
 in
-  pkgs.dockerTools.buildLayeredImageWithNixDb {
-    inherit name tag maxLayers;
+pkgs.dockerTools.buildLayeredImageWithNixDb {
+  inherit name tag maxLayers;
 
-    contents = [baseSystem];
+  contents = [ baseSystem ];
 
-    extraCommands =
-      ''
-        rm -rf nix-support
-        ln -s /nix/var/nix/profiles nix/var/nix/gcroots/profiles
-      ''
-      + image-extraCommands;
-    fakeRootCommands = let
+  extraCommands =
+    ''
+      rm -rf nix-support
+      ln -s /nix/var/nix/profiles nix/var/nix/gcroots/profiles
+    ''
+    + image-extraCommands;
+  fakeRootCommands =
+    let
       sudo = pkgs.sudo;
       sudoLocalPath = builtins.substring 1 999 "${sudo}/bin/sudo";
-    in ''
+    in
+    ''
       set -e
       chmod 1777 tmp
       chmod 1777 var/tmp
@@ -369,27 +361,31 @@ in
       fi
     '';
 
-    config = {
-      Cmd = image-config-cmd;
-      WorkingDir = image-config-cwd;
-      Env =
-        [
-          "USER=root"
-          "PATH=${lib.concatStringsSep ":" (image-config-extra-path
-            ++ [
-              "/root/.nix-profile/bin"
-              "/nix/var/nix/profiles/default/bin"
-              "/nix/var/nix/profiles/default/sbin"
-            ])}"
-          "MANPATH=${lib.concatStringsSep ":" [
-            "/root/.nix-profile/share/man"
-            "/nix/var/nix/profiles/default/share/man"
-          ]}"
-          "SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
-          "GIT_SSL_CAINFO=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
-          "NIX_SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
-          "NIX_PATH=/nix/var/nix/profiles/per-user/root/channels:/root/.nix-defexpr/channels"
+  config = {
+    Cmd = image-config-cmd;
+    WorkingDir = image-config-cwd;
+    Env = [
+      "USER=root"
+      "PATH=${
+        lib.concatStringsSep ":" (
+          image-config-extra-path
+          ++ [
+            "/root/.nix-profile/bin"
+            "/nix/var/nix/profiles/default/bin"
+            "/nix/var/nix/profiles/default/sbin"
+          ]
+        )
+      }"
+      "MANPATH=${
+        lib.concatStringsSep ":" [
+          "/root/.nix-profile/share/man"
+          "/nix/var/nix/profiles/default/share/man"
         ]
-        ++ image-config-extra-env;
-    };
-  }
+      }"
+      "SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+      "GIT_SSL_CAINFO=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+      "NIX_SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+      "NIX_PATH=/nix/var/nix/profiles/per-user/root/channels:/root/.nix-defexpr/channels"
+    ] ++ image-config-extra-env;
+  };
+}

--- a/nix/fetch_github_snapshot.nix
+++ b/nix/fetch_github_snapshot.nix
@@ -1,19 +1,5 @@
-# Copyright 2025 nix-eda Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Code adapated from Nixpkgs, original license follows:
-# ---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
 # Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -38,7 +24,8 @@
   stdenvNoCC,
   python3,
   preferLocalBuild ? true,
-}: {
+}:
+{
   owner,
   repo,
   rev,
@@ -47,25 +34,26 @@
 stdenvNoCC.mkDerivation {
   name = "github-${repo}-${rev}-snapshot";
   nativeBuildInputs = [
-    (python3.withPackages (ps: with ps; [click httpx truststore]))
+    (python3.withPackages (
+      ps: with ps; [
+        click
+        httpx
+        truststore
+      ]
+    ))
   ];
-  phases = ["installPhase"];
+  phases = [ "installPhase" ];
   installPhase = ''
     python3 ${./supporting/download_github_snapshot.py} \
       --out-dir $out \
       https://github.com/${owner}/${repo} \
       ${rev}
   '';
-  impureEnvVars =
-    lib.fetchers.proxyImpureEnvVars
-    ++ [
-      "GITHUB_TOKEN"
-    ];
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+    "GITHUB_TOKEN"
+  ];
   outputHash = hash;
-  outputHashAlgo =
-    if hash == ""
-    then "sha256"
-    else null;
+  outputHashAlgo = if hash == "" then "sha256" else null;
   outputHashMode = "recursive";
   inherit preferLocalBuild;
 }

--- a/nix/gdsfactory.nix
+++ b/nix/gdsfactory.nix
@@ -1,20 +1,25 @@
-# Copyright 2025 nix-eda Contributors
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 #
-# Adapted from efabless/nix-eda
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-# Copyright 2024 Efabless Corporation
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   buildPythonPackage,
@@ -58,7 +63,8 @@
   # Metadata
   version ? "9.9.1",
   sha256 ? "sha256-rL/9clBJq/z7PyKKArGuAx2xtxce/3N3oPMIOiZA3VU=",
-}: let
+}:
+let
   self = buildPythonPackage {
     pname = "gdsfactory";
     format = "pyproject";
@@ -104,17 +110,17 @@
       pyglet
     ];
 
-    nativeCheckInputs = [pytestCheckHook];
+    nativeCheckInputs = [ pytestCheckHook ];
 
     doCheck = true;
 
     meta = {
       description = "python library to design chips (Photonics, Analog, Quantum, MEMs, ...), objects for 3D printing or PCBs.";
       homepage = "https://gdsfactory.github.io/gdsfactory/";
-      license = [lib.licenses.mit];
+      license = [ lib.licenses.mit ];
       platforms = lib.platforms.unix;
       mainProgram = "gf";
     };
   };
 in
-  self
+self

--- a/nix/gdstk.nix
+++ b/nix/gdstk.nix
@@ -1,3 +1,25 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024-2025 UmbraLogic Technologies LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   buildPythonPackage,
@@ -12,7 +34,8 @@
   pyproject-metadata,
   version ? "0.9.52",
   sha256 ? "sha256-QiZyktJy9KTIIpCR3IOkltChX5ac82aTtVl9P+jvuS8=",
-}: let
+}:
+let
   self = buildPythonPackage {
     pname = "gdstk";
     format = "pyproject";
@@ -50,9 +73,9 @@
     meta = {
       description = "Python module for creation and manipulation of GDSII files.";
       homepage = "https://github.com/heitzmann/gdstk";
-      license = [lib.licenses.boost];
+      license = [ lib.licenses.boost ];
       platforms = lib.platforms.unix;
     };
   };
 in
-  self
+self

--- a/nix/ghdl-bin.nix
+++ b/nix/ghdl-bin.nix
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
 {
   lib,
   system,
@@ -10,79 +12,85 @@
   zlib,
   python3,
   data ? (builtins.fromTOML (builtins.readFile ./ghdl-bin.toml)),
-}: let
+}:
+let
   version = data.version;
   system-data = data."${system}";
 in
-  stdenv.mkDerivation (finalAttrs: {
-    pname = "ghdl-bin";
-    inherit version;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ghdl-bin";
+  inherit version;
 
-    src = fetchurl {
-      url = "https://github.com/ghdl/ghdl/releases/download/v${finalAttrs.version}/ghdl-${system-data.backend}-${finalAttrs.version}-${system-data.platform_double}.tar.gz";
-      inherit (system-data) sha256;
-    };
+  src = fetchurl {
+    url = "https://github.com/ghdl/ghdl/releases/download/v${finalAttrs.version}/ghdl-${system-data.backend}-${finalAttrs.version}-${system-data.platform_double}.tar.gz";
+    inherit (system-data) sha256;
+  };
 
-    buildInputs = [
-      zlib
+  buildInputs = [
+    zlib
+  ];
+
+  nativeBuildInputs =
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      autoPatchelfHook
+      patchelfUnstable
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+      (python3.withPackages (
+        ps: with ps; [
+          lief
+          click
+        ]
+      ))
+      darwin.autoSignDarwinBinariesHook
     ];
 
-    nativeBuildInputs =
-      lib.optionals (!stdenv.hostPlatform.isDarwin) [
-        autoPatchelfHook
-        patchelfUnstable
-      ]
-      ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-        (python3.withPackages (ps: with ps; [lief click]))
-        darwin.autoSignDarwinBinariesHook
-      ];
+  buildPhase = "true";
 
-    buildPhase = "true";
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r bin $out/bin
+    cp -r include $out/include
+    cp -r lib $out/lib
+    runHook postInstall
+  '';
 
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out
-      cp -r bin $out/bin
-      cp -r include $out/include
-      cp -r lib $out/lib
-      runHook postInstall
+  fixupPhase =
+    lib.optionalString (!stdenv.isDarwin) "exit -1" # TODO
+    + lib.optionalString (stdenv.isDarwin) ''
+      runHook preFixup
+      install_name_tool \
+        -change /usr/lib/libc++.1.dylib ${stdenv.cc.libcxx}/lib/libc++.1.dylib \
+        -change /usr/lib/libz.1.dylib ${zlib}/lib/libz.1.dylib \
+        $out/bin/ghdl1-llvm
+      clang \
+        -x c\
+        -dynamiclib \
+        -D GHDL_PREFIX=\"$out/lib/ghdl\" \
+        -o $out/lib/set_ghdl_pfx.dylib \
+        -install_name $out/lib/set_ghdl_pfx.dylib \
+        - <<'EOF'
+        #include <stdlib.h>
+
+        __attribute__((constructor))
+        static void set_ghdl_pfx(void) {
+            if (!getenv("GHDL_PREFIX")) {
+                setenv("GHDL_PREFIX", GHDL_PREFIX, 1);
+            }
+        }
+      EOF
+      python3 ${./supporting/lief_inject_dylib.py} \
+        --inject $out/lib/set_ghdl_pfx.dylib \
+        --inplace $out/lib/libghdl-*.dylib
+      runHook postFixup
     '';
 
-    fixupPhase =
-      lib.optionalString (!stdenv.isDarwin) "exit -1" # TODO
-      + lib.optionalString (stdenv.isDarwin) ''
-        runHook preFixup
-        install_name_tool \
-          -change /usr/lib/libc++.1.dylib ${stdenv.cc.libcxx}/lib/libc++.1.dylib \
-          -change /usr/lib/libz.1.dylib ${zlib}/lib/libz.1.dylib \
-          $out/bin/ghdl1-llvm
-        clang \
-          -x c\
-          -dynamiclib \
-          -D GHDL_PREFIX=\"$out/lib/ghdl\" \
-          -o $out/lib/set_ghdl_pfx.dylib \
-          -install_name $out/lib/set_ghdl_pfx.dylib \
-          - <<'EOF'
-          #include <stdlib.h>
-
-          __attribute__((constructor))
-          static void set_ghdl_pfx(void) {
-              if (!getenv("GHDL_PREFIX")) {
-                  setenv("GHDL_PREFIX", GHDL_PREFIX, 1);
-              }
-          }
-        EOF
-        python3 ${./supporting/lief_inject_dylib.py} \
-          --inject $out/lib/set_ghdl_pfx.dylib \
-          --inplace $out/lib/libghdl-*.dylib
-        runHook postFixup
-      '';
-
-    meta = {
-      description = "VHDL 2008/93/87 simulator";
-      homepage = "https://github.com/ghdl/ghdl";
-      license = lib.licenses.gpl2Plus;
-      platforms = lib.lists.remove "version" (builtins.attrNames data);
-      broken = !stdenv.isDarwin;
-    };
-  })
+  meta = {
+    description = "VHDL 2008/93/87 simulator";
+    homepage = "https://github.com/ghdl/ghdl";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.lists.remove "version" (builtins.attrNames data);
+    broken = !stdenv.isDarwin;
+  };
+})

--- a/nix/iverilog.nix
+++ b/nix/iverilog.nix
@@ -1,18 +1,5 @@
-# Copyright 2025 nix-eda Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# Code adapated from nixpkgs, original license follows
-# ---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
 # Copyright (c) 2003-2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -60,10 +47,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "steveicarus";
     repo = "iverilog";
-    rev =
-      if rev == null
-      then "v${lib.replaceStrings ["."] ["_"] version}"
-      else rev;
+    rev = if rev == null then "v${lib.replaceStrings [ "." ] [ "_" ] version}" else rev;
     inherit sha256;
   };
 
@@ -106,10 +90,9 @@ stdenv.mkDerivation {
   nativeInstallCheckInputs = [
     perl
     (python3.withPackages (
-      pp:
-        with pp; [
-          docopt
-        ]
+      pp: with pp; [
+        docopt
+      ]
     ))
   ];
 

--- a/nix/klayout-gdsfactory.nix
+++ b/nix/klayout-gdsfactory.nix
@@ -1,18 +1,27 @@
-# Copyright 2024 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-{klayout}:
-klayout.withPythonPackages (ps:
-    with ps; [
-      gdsfactory
-    ])
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+{ klayout }:
+klayout.withPythonPackages (
+  ps: with ps; [
+    gdsfactory
+  ]
+)

--- a/nix/klayout.nix
+++ b/nix/klayout.nix
@@ -1,22 +1,6 @@
-# Copyright 2025 nix-eda Contributors
-#
-# Adapted from efabless/nix-eda
-#
-# Copyright 2023 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# Code adapated from Nixpkgs, original license follows:
-# ---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 # Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -63,7 +47,10 @@ clangStdenv.mkDerivation {
   pname = "klayout";
   inherit version;
 
-  outputs = ["out" "python"];
+  outputs = [
+    "out"
+    "python"
+  ];
 
   src = fetchurl {
     url = "https://github.com/KLayout/klayout/archive/refs/tags/v${version}.tar.gz";
@@ -82,7 +69,7 @@ clangStdenv.mkDerivation {
   nativeBuildInputs = [
     which
     perl
-    (python3.withPackages (ps: with ps; [setuptools]))
+    (python3.withPackages (ps: with ps; [ setuptools ]))
     ruby
     gnused
     libsForQt5.wrapQtAppsHook
@@ -138,13 +125,14 @@ clangStdenv.mkDerivation {
       ln -s $out/lib/pymod/klayout*.dist-info $python/${python3.sitePackages}/
     ''
     + (
-      if clangStdenv.isDarwin
-      then ''
-        cp $out/lib/klayout.app/Contents/MacOS/klayout $out/bin/
-      ''
-      else ''
-        cp $out/lib/klayout $out/bin/
-      ''
+      if clangStdenv.isDarwin then
+        ''
+          cp $out/lib/klayout.app/Contents/MacOS/klayout $out/bin/
+        ''
+      else
+        ''
+          cp $out/lib/klayout $out/bin/
+        ''
     );
 
   # The automatic Qt wrapper overrides makeWrapperArgs
@@ -165,7 +153,7 @@ clangStdenv.mkDerivation {
 
   meta = with lib; {
     description = "High performance layout viewer and editor with support for GDS and OASIS";
-    license = with licenses; [gpl3Plus];
+    license = with licenses; [ gpl3Plus ];
     homepage = "https://www.klayout.de/";
     changelog = "https://www.klayout.de/development.html#${version}";
     platforms = platforms.linux ++ platforms.darwin;

--- a/nix/magic.nix
+++ b/nix/magic.nix
@@ -1,18 +1,6 @@
-# Copyright 2023 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# Code adapated from Nixpkgs, original license follows:
-# ---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 # Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -56,14 +44,14 @@ clangStdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";
     repo = "magic";
-    rev =
-      if rev == null
-      then version
-      else rev;
+    rev = if rev == null then version else rev;
     inherit sha256;
   };
 
-  nativeBuildInputs = [python3 gnused];
+  nativeBuildInputs = [
+    python3
+    gnused
+  ];
 
   buildInputs = [
     xorg.libX11

--- a/nix/netgen.nix
+++ b/nix/netgen.nix
@@ -1,16 +1,23 @@
-# Copyright 2023 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   clangStdenv,
@@ -30,10 +37,7 @@ clangStdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";
     repo = "netgen";
-    rev =
-      if rev == null
-      then version
-      else rev;
+    rev = if rev == null then version else rev;
     inherit sha256;
   };
 

--- a/nix/ngspice.nix
+++ b/nix/ngspice.nix
@@ -1,18 +1,6 @@
-# Copyright 2024 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# Code adapated from Nixpkgs, original license follows:
-# ---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 # Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -101,7 +89,11 @@ clangStdenv.mkDerivation {
   meta = with lib; {
     description = "The Next Generation Spice (Electronic Circuit Simulator)";
     homepage = "http://ngspice.sourceforge.net";
-    license = with licenses; [bsd3 gpl2Plus lgpl2Plus]; # See https://sourceforge.net/p/ngspice/ngspice/ci/master/tree/COPYING
+    license = with licenses; [
+      bsd3
+      gpl2Plus
+      lgpl2Plus
+    ]; # See https://sourceforge.net/p/ngspice/ngspice/ci/master/tree/COPYING
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/nix/pyglet.nix
+++ b/nix/pyglet.nix
@@ -40,7 +40,6 @@
   mesa,
   apple-sdk,
 }:
-
 buildPythonPackage rec {
   version = "2.0.10";
   format = "setuptools";
@@ -143,7 +142,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  preCheck = # libEGL only available on Linux (despite meta.platforms on libGL)
+  preCheck =
+    # libEGL only available on Linux (despite meta.platforms on libGL)
     lib.optionalString stdenv.isLinux ''
       export PYGLET_HEADLESS=True
     '';

--- a/nix/python3-antlr4-runtime.nix
+++ b/nix/python3-antlr4-runtime.nix
@@ -1,16 +1,24 @@
-# Copyright 2024 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   buildPythonPackage,

--- a/nix/supporting/download_github_snapshot.py
+++ b/nix/supporting/download_github_snapshot.py
@@ -1,25 +1,29 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2021 UmbraLogic Technologies LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 # Adapted from OpenLane Build Scripts
 #
 # https://github.com/The-OpenROAD-Project/OpenLane/blob/3c41826a8aaaf724e423593ddc7bea392e65277e/docker/utils.py
-#
-# and Volare
-#
-#
-#
-# Copyright 2021 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 import ssl
 import json
 import re

--- a/nix/tclFull.nix
+++ b/nix/tclFull.nix
@@ -1,16 +1,24 @@
-# Copyright 2024 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   symlinkJoin,
   tcl,

--- a/nix/tclint.nix
+++ b/nix/tclint.nix
@@ -1,16 +1,24 @@
-# Copyright 2024 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   fetchFromGitHub,
@@ -24,7 +32,8 @@
   setuptools_scm,
   version ? "0.5.0",
   sha256 ? "sha256-FT0a0pYhpsr0xlehrg+QqyPqOaM0paU+iG0+Bx8tDrU=",
-}: let
+}:
+let
   self = buildPythonPackage {
     pname = "tclint";
     inherit version;
@@ -59,4 +68,4 @@
     ];
   };
 in
-  self
+self

--- a/nix/tk-x11.nix
+++ b/nix/tk-x11.nix
@@ -1,16 +1,25 @@
-# Copyright 2024 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 # This is a modification of TK that explicitly uses X11 regardless of platform.
 #
 # This is important for some utilities such as Xschem which expect the X11
@@ -21,19 +30,17 @@
 }:
 (tk.override {
   enableAqua = false;
-})
-.overrideAttrs (self: super: {
-  configureFlags =
-    super.configureFlags
-    ++ [
-      "--with-x"
-      "--x-includes=${xorg.libX11}/include"
-      "--x-libraries=${xorg.libX11}/lib"
-    ];
+}).overrideAttrs
+  (
+    self: super: {
+      configureFlags = super.configureFlags ++ [
+        "--with-x"
+        "--x-includes=${xorg.libX11}/include"
+        "--x-libraries=${xorg.libX11}/lib"
+      ];
 
-  propagatedBuildInputs =
-    super.propagatedBuildInputs
-    ++ [
-      xorg.libX11
-    ];
-})
+      propagatedBuildInputs = super.propagatedBuildInputs ++ [
+        xorg.libX11
+      ];
+    }
+  )

--- a/nix/verilator.nix
+++ b/nix/verilator.nix
@@ -1,18 +1,5 @@
-# Copyright 2025 nix-eda Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# Code adapated from nixpkgs, original license follows
-# ---
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
 # Copyright (c) 2003-2025 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -25,7 +12,6 @@
 #
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -66,10 +52,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "verilator";
     repo = "verilator";
-    rev =
-      if rev == null
-      then "v${version}"
-      else rev;
+    rev = if rev == null then "v${version}" else rev;
     inherit sha256;
   };
 
@@ -78,10 +61,9 @@ stdenv.mkDerivation {
     perl
     systemc
     (python3.withPackages (
-      pp:
-        with pp; [
-          distro
-        ]
+      pp: with pp; [
+        distro
+      ]
     ))
     # ccache
   ];

--- a/nix/xschem.nix
+++ b/nix/xschem.nix
@@ -1,17 +1,6 @@
-# Copyright 2024 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
 # Copyright (c) 2003-2024 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -24,7 +13,6 @@
 #
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -54,18 +42,25 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "StefanSchippers";
     repo = "xschem";
-    rev =
-      if rev == null
-      then version
-      else rev;
+    rev = if rev == null then version else rev;
     inherit sha256;
   };
 
-  nativeBuildInputs = [bison flex pkg-config];
+  nativeBuildInputs = [
+    bison
+    flex
+    pkg-config
+  ];
 
-  buildInputs = [cairo xorg.libX11 xorg.libXpm tcl tk-x11];
+  buildInputs = [
+    cairo
+    xorg.libX11
+    xorg.libXpm
+    tcl
+    tk-x11
+  ];
 
-  hardeningDisable = ["format"];
+  hardeningDisable = [ "format" ];
 
   meta = with lib; {
     description = "Schematic capture and netlisting EDA tool";

--- a/nix/xyce.nix
+++ b/nix/xyce.nix
@@ -1,16 +1,25 @@
-# Copyright 2024 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2024 UmbraLogic Technologies LLC
+# Copyright (c) 2003-2024 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   stdenv,
   fetchFromGitHub,
@@ -64,7 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = regression-sha256;
   };
 
-  srcs = [finalAttrs.xyce_src finalAttrs.regression_src];
+  srcs = [
+    finalAttrs.xyce_src
+    finalAttrs.regression_src
+  ];
 
   sourceRoot = finalAttrs.xyce_src.name;
 
@@ -95,8 +107,8 @@ stdenv.mkDerivation (finalAttrs: {
       libtool_2
     ]
     ++ lib.optionals enableDocs [
-      (texliveMedium.withPackages (ps:
-        with ps; [
+      (texliveMedium.withPackages (
+        ps: with ps; [
           enumitem
           koma-script
           optional
@@ -105,20 +117,19 @@ stdenv.mkDerivation (finalAttrs: {
           multirow
           newtx
           preprint
-        ]))
+        ]
+      ))
     ];
 
-  buildInputs =
-    [
-      bison
-      blas
-      flex
-      fftw
-      lapack
-      suitesparse
-      trilinos
-    ]
-    ++ lib.optionals trilinos.withMPI [mpi];
+  buildInputs = [
+    bison
+    blas
+    flex
+    fftw
+    lapack
+    suitesparse
+    trilinos
+  ] ++ lib.optionals trilinos.withMPI [ mpi ];
 
   doCheck = enableTests;
 
@@ -141,9 +152,17 @@ stdenv.mkDerivation (finalAttrs: {
     [
       bc
       perl
-      (python3.withPackages (ps: with ps; [numpy scipy]))
+      (python3.withPackages (
+        ps: with ps; [
+          numpy
+          scipy
+        ]
+      ))
     ]
-    ++ lib.optionals trilinos.withMPI [mpi openssh];
+    ++ lib.optionals trilinos.withMPI [
+      mpi
+      openssh
+    ];
 
   checkPhase = ''
     XYCE_BINARY="$(pwd)/src/Xyce"
@@ -168,7 +187,10 @@ stdenv.mkDerivation (finalAttrs: {
       "''${EXECSTRING}"
   '';
 
-  outputs = ["out" "doc"];
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   postInstall = lib.optionalString enableDocs ''
     local docFiles=("doc/Users_Guide/Xyce_UG"

--- a/nix/yosys-eqy.nix
+++ b/nix/yosys-eqy.nix
@@ -1,16 +1,24 @@
-# Copyright 2023 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   fetchFromGitHub,

--- a/nix/yosys-ghdl.nix
+++ b/nix/yosys-ghdl.nix
@@ -1,20 +1,6 @@
-# Copyright 2023 Efabless Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Code adapated from Nixpkgs, original license follows:
-# ---
-# Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -48,7 +34,7 @@ yosys.stdenv.mkDerivation {
   pname = "yosys-ghdl";
   version = rev-date;
 
-  dylibs = ["ghdl"];
+  dylibs = [ "ghdl" ];
 
   src = fetchFromGitHub {
     owner = "ghdl";

--- a/nix/yosys-lighter.nix
+++ b/nix/yosys-lighter.nix
@@ -1,16 +1,24 @@
-# Copyright 2023 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   fetchFromGitHub,
@@ -24,7 +32,7 @@ yosys.stdenv.mkDerivation (finalAttrs: {
   pname = "yosys-lighter";
   version = rev-date;
 
-  dylibs = ["lighter"];
+  dylibs = [ "lighter" ];
 
   src = fetchFromGitHub {
     owner = "aucohl";

--- a/nix/yosys-sby.nix
+++ b/nix/yosys-sby.nix
@@ -1,16 +1,25 @@
-# Copyright 2023 Efabless Corporation
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+# Copyright (c) 2023 UmbraLogic Technologies LLC
+# Copyright (c) 2003-2024 Eelco Dolstra and the Nixpkgs/NixOS contributors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   yosys,
@@ -25,7 +34,7 @@
 yosys.stdenv.mkDerivation (finalAttrs: {
   pname = "yosys-sby";
   inherit version;
-  dylibs = [];
+  dylibs = [ ];
 
   src = fetchFromGitHub {
     owner = "yosyshq";

--- a/nix/yosys-slang.nix
+++ b/nix/yosys-slang.nix
@@ -1,16 +1,23 @@
-# Copyright 2025 nix-eda Contributors
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 {
   lib,
   yosys,
@@ -26,7 +33,7 @@
 clang18Stdenv.mkDerivation {
   name = "yosys-slang";
   version = rev-date;
-  dylibs = ["slang"];
+  dylibs = [ "slang" ];
 
   src = fetchGitHubSnapshot {
     owner = "povik";
@@ -40,8 +47,15 @@ clang18Stdenv.mkDerivation {
     "-DFMT_INSTALL:BOOL=OFF"
   ];
 
-  nativeBuildInputs = [cmake jq]; # ninja doesn't work, cba to debug why
-  buildInputs = [yosys yosys.python3-env fmt];
+  nativeBuildInputs = [
+    cmake
+    jq
+  ]; # ninja doesn't work, cba to debug why
+  buildInputs = [
+    yosys
+    yosys.python3-env
+    fmt
+  ];
 
   patchPhase = ''
     runHook prePatch
@@ -67,7 +81,7 @@ clang18Stdenv.mkDerivation {
 
   meta = {
     description = "SystemVerilog frontend for Yosys";
-    license = [lib.licenses.mit];
+    license = [ lib.licenses.mit ];
     homepage = "https://github.com/povik/yosys-slang";
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
We have communicated with UmbraLogic Technologies LLC (dba ChipFoundry), the current proprietor of Efabless Corporation assets, and they have agreed to relicense all Nix code in both https://github.com/efabless/nix-eda and all Nix code in https://github.com/efabless/openlane2 under the MIT license to be compatible with nixpkgs's license terms for upstreaming.

We also adopted nixpkgs' code formatter.

This should hopefully help us upstream some of the more… presentable files.

Also, both macOS runners have been updated to macOS 15.