### PR TITLE
chore: switch to lix, update nix_copy_s3.py

### DIFF
--- a/.github/actions/install_nix/action.yml
+++ b/.github/actions/install_nix/action.yml
@@ -18,15 +18,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Upstream Nix
-      uses: DeterminateSystems/nix-installer-action@main
-      with:
-        # OpenLane cachix temporarily included until most things copied over
-        determinate: false
-        extra-conf: |
+    - name: Install Lix
+      shell: bash
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf -L https://install.lix.systems/lix | sh -s -- install --no-confirm --extra-conf "
           access-tokens = github.com=${{ inputs.github_token }}
-          extra-substituters = https://${{ inputs.nix_cache_domain }} https://openlane.cachix.org
-          extra-trusted-public-keys = ${{ inputs.nix_public_key }} openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+          experimental-features = nix-command flakes
+        "
+        echo "extra-substituters = https://${{ inputs.nix_cache_domain }}" | sudo tee -a /etc/nix/nix.conf
+        echo "extra-trusted-public-keys = ${{ inputs.nix_public_key }}" | sudo tee -a /etc/nix/nix.conf
     - name: Linux -- inject GITHUB_TOKEN environment variable into nix-daemon.service
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/actions/nix_sign_cache_s3/action.yml
+++ b/.github/actions/nix_sign_cache_s3/action.yml
@@ -1,10 +1,10 @@
 name: Sign & Cache Nix Build (S3)
 description: |
   Caches any Nix builds in AWS S3.
-  
+
   Requires Nix and AWSCLI to both be installed in the calling workflow
   beforehand.
-  
+
   Requires Nix builds to have actually occurred beforehand.
 inputs:
   shell:
@@ -56,7 +56,7 @@ runs:
         umask 077
         echo "${{ inputs.nix_private_key }}" > ~/nix-private-key
         for output in ${{ inputs.flake_outputs }}; do
-          nix store sign --recursive --key-file ~/nix-private-key $output && echo "Successfully signed $output" || echo "Failed to sign $output"
+          nix store sign --recursive --key-file ~/nix-private-key $output && echo "Successfully signed $output" || echo "Failed to sign $output - skipping"
         done
     - name: Push to S3 Cache
       shell: ${{ inputs.shell }}
@@ -64,6 +64,7 @@ runs:
       run: |
         python3 ${{ github.action_path }}/nix_copy_s3.py \
           --upstream-cache "https://cache.nixos.org" \
+          --upstream-cache "TARGET_HTTPS" \
           --to-s3-bucket "${{ inputs.s3_bucket_name }}" \
           --verify-signature-key "${{ inputs.nix_public_key }}" \
           ${{ inputs.flake_outputs }}

--- a/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
+++ b/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
@@ -37,11 +37,13 @@ import os
 import re
 import json
 import argparse
+import shlex
 import sys
 import tempfile
 import subprocess
 import logging
 from typing import Any, List, Dict, Set
+from urllib.parse import urlparse
 
 ws_rx = re.compile(r"\s+")
 
@@ -76,6 +78,8 @@ def parse_narinfo(file: io.TextIOWrapper):
 def check_json_out(args: List[str], **kwargs):
     if "encoding" not in kwargs:
         kwargs["encoding"] = "utf8"
+    if os.getenv("VERBOSE", "0") == "1":
+        print(f"$ {shlex.join(args)}", file=sys.stderr)
     out_str = subprocess.check_output(args, **kwargs)
     return json.loads(out_str)
 
@@ -97,8 +101,10 @@ def main(text_args):
     args.add_argument(
         "-u",
         "--upstream-cache",
-        help="Check this upstream cache before uploading to the supplementary S3 bucket-based cache.",
+        help="Check if the paths exist in any of these upstream caches before attempting to upload to the S3 cache. If an element is the exact string 'TARGET_HTTPS', the final s3 cache is assumed accessible over HTTPS and also checked.",
         required=True,
+        nargs="+",
+        action="extend",
     )
     args.add_argument(
         "-t",
@@ -118,12 +124,24 @@ def main(text_args):
     paths_queried: Set[str] = set()
     paths_in_upstream_caches: Dict[str, str] = {}
 
+    s3_nix_url = args_parsed.to_s3_bucket
+    if "://" not in s3_nix_url:
+        s3_nix_url = f"s3://{s3_nix_url}"
+    s3_nix_url = urlparse(s3_nix_url)._replace(scheme="s3")
+
+    upstream_caches = []
+    for cache in args_parsed.upstream_cache:
+        if cache == "TARGET_HTTPS":
+            upstream_caches.append(s3_nix_url._replace(scheme="https").geturl())
+        else:
+            upstream_caches.append(cache)
+
     for i, flake_output in enumerate(args_parsed.flake_outputs):
         logging.info(
             f"Processing {flake_output} ({i + 1}/{len(args_parsed.flake_outputs)})…"
         )
 
-        # 0. List all paths that this flake output depends on.
+        # 0. List all paths that this flake output depends on, the "closure"
         try:
             closure_raw: Any = check_json_out(
                 ["nix", "path-info", "--recursive", "--json", flake_output],
@@ -135,6 +153,11 @@ def main(text_args):
                     f"Failed to get store paths for {flake_output} -- assuming broken, skipping…"
                 )
                 continue
+            elif "does not exist in the store" in e.stderr:
+                logging.warning(
+                    f"{flake_output} does not exist in the store, possibly unbuilt. Skipping…"
+                )
+                continue
             else:
                 raise e from None
 
@@ -142,47 +165,44 @@ def main(text_args):
         if closure is None:
             continue
 
-        # 1. Check which paths have already been queried upstream, and
-        # which need to be queried.
+        # 1. Check which paths have already been queried in previous attempts
+        #    to avoid hammering upstreams.
         paths_to_query: Set[str] = set()
         for path in closure:
             if path not in paths_queried:
                 paths_to_query.add(path)
-                paths_queried.add(path)
 
-        # 2. Query paths that need to be queried against upstream.
+        # 2. Query any paths that have not already been queried
         if len(paths_to_query):
             logging.info("Checking for paths upstream…")
-            upstream_cache_info_raw = check_json_out(
-                [
-                    "nix",
-                    "path-info",
-                    "--json",
-                    "--eval-store",
-                    "",
-                    "--store",
-                    args_parsed.upstream_cache,
-                    *paths_to_query,
-                ],
-                stderr=subprocess.PIPE,
-            )
-            upstream_cache_paths = paths_from_path_info(upstream_cache_info_raw)
-            if upstream_cache_paths is None:
-                continue
+            for cache in upstream_caches:
+                upstream_cache_info_raw = check_json_out(
+                    [
+                        "nix",
+                        "path-info",
+                        "--json",
+                        "--eval-store",
+                        "",
+                        "--store",
+                        cache,
+                        *paths_to_query,
+                    ],
+                    stderr=subprocess.PIPE,
+                )
+                upstream_cache_paths = paths_from_path_info(upstream_cache_info_raw)
+                if upstream_cache_paths is None:
+                    continue
 
-            # 2a. Update list of paths known to be upstream
-            #
-            #    We store which cache for the probability of supporting multiple
-            #    caches in the future. Don't count on it though.
-            paths_in_upstream_caches.update(
-                {path: args_parsed.upstream_cache for path in upstream_cache_paths}
-            )
+                paths_in_upstream_caches.update(
+                    {path: cache for path in upstream_cache_paths}
+                )
+            paths_queried |= paths_to_query
 
         # 3. Upload remaining paths from closure, if any, to our S3-based cache.
         difference = closure - set(paths_in_upstream_caches.keys())
         if len(difference):
             logging.info(
-                "One or more paths not found in upstream cache and will be uploaded:"
+                "One or more paths not found in upstream caches and will be uploaded:"
             )
             for path in difference:
                 logging.info(f"* {path}")
@@ -190,15 +210,13 @@ def main(text_args):
             # 0. copy the full closure with zstd compression to a temporary
             #    directory
             # 1. check which .narinfo and .nar.zstd files correspond to the
-            #    missing cache in the directory, and add them to a "sync"
+            #    missing paths in the directory, and add them to a "sync"
             #    list.
             # 2. Invoke aws s3 sync. Because --size-only is passed, any paths
             #    already in the cache will not be uploaded.
             # ---
             # Potential improvements:
             #
-            # * Query cache to verify the paths don't already exist there
-            #   to save time on nix copy
             # * Only nix copy paths that we care about uploading -- blocked on
             #    https://github.com/NixOS/nix/issues/12835
             with tempfile.TemporaryDirectory(prefix="nix-eda-copy-uncache") as temp_dir:
@@ -244,6 +262,8 @@ def main(text_args):
                         "--include",
                         os.path.basename(narinfo_path),
                         "--include",
+                        # despite its name, thats just a relative path to the
+                        # .tar.zst
                         narinfo["URL"],
                     ]
                 if len(sync_include_args):
@@ -254,7 +274,7 @@ def main(text_args):
                             "s3",
                             "sync",
                             d,
-                            f"s3://{args_parsed.to_s3_bucket}",
+                            s3_nix_url._replace(query="").geturl(),
                             "--size-only",
                             "--exclude",
                             "*",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           exit $error
       - name: Sign and Cache Nix Builds to S3
         uses: ./.github/actions/nix_sign_cache_s3
-        if: steps.enumerate_packages.outcome == 'success'
+        if: "!cancelled() && steps.enumerate_packages.outcome == 'success'"
         with:
           flake_outputs: ${{ env.FLAKE_OUTPUTS }}
           nix_public_key: ${{ vars.NIX_PUBLIC_KEY }}

--- a/.github/workflows/get_all_packages.py
+++ b/.github/workflows/get_all_packages.py
@@ -1,6 +1,6 @@
-import sys
 import json
 import subprocess
+import sys
 
 
 def run(purpose, *args):
@@ -17,11 +17,14 @@ def run(purpose, *args):
         exit(-1)
     return process.stdout
 
+
 system = tuple()
 if len(sys.argv) > 1:
     system = ("--system", sys.argv[1])
 
-flake_meta = json.load(run("get flake metadata", "nix", "flake", "show", *system, "--json"))
+flake_meta = json.load(
+    run("get flake metadata", "nix", "flake", "show", *system, "--json")
+)
 packages = flake_meta["packages"]
 for platform, packages in packages.items():
     for package, package_info in packages.items():
@@ -35,7 +38,7 @@ for platform, packages in packages.items():
         keys = list(drv.keys())
         if len(keys) != 1:
             print(
-                f"'nix derivation show' unexpectedly returned {len(keys)} paths, expected exactly 1: {tgt}",
+                f"'nix derivation show' unexpectedly returned {len(keys)} paths, expected exactly 1: {tgt}, {keys}",
                 file=sys.stderr,
             )
             exit(-1)

--- a/flake.nix
+++ b/flake.nix
@@ -212,7 +212,6 @@
             yosys-slang
             ;
           inherit (pkgs.python3.pkgs) gdsfactory gdstk tclint;
-          potato = pkgs.stdenv.mkDerivation { name = "potato"; }; # intentionally failing package to test something
         }
         // lib.optionalAttrs self.legacyPackages."${system}".stdenv.hostPlatform.isLinux {
           inherit (pkgs) xyce;

--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,7 @@
             yosys-slang
             ;
           inherit (pkgs.python3.pkgs) gdsfactory gdstk tclint;
+          potato = pkgs.stdenv.mkDerivation { name = "potato"; }; # intentionally failing package to test something
         }
         // lib.optionalAttrs self.legacyPackages."${system}".stdenv.hostPlatform.isLinux {
           inherit (pkgs) xyce;


### PR DESCRIPTION
Given the determinate systems installer is about to drop upstream nix and the upstream fork of [nix-installer](https://github.com/NixOS/nix-installer) being experimental, it's time to just move. The repo and cache are still compatible with CppNix and DetNix, so this really doesn't matter much.

`nix_copy_s3.py` has been updated to support both Nix and Lix; but also to optionally query the final cache so we avoid the costly `nix copy` step if a package has not changed.