### PR TITLE
fix: incorrect mainProgram for Xyce

### DIFF
--- a/nix/xyce.nix
+++ b/nix/xyce.nix
@@ -219,6 +219,7 @@ stdenv.mkDerivation (finalAttrs: {
       capable of solving extremely large circuit problems by supporting
       large-scale parallel computing platforms.
     '';
+    mainProgram = "Xyce";
     homepage = "https://xyce.sandia.gov";
     license = lib.licenses.gpl3;
     platforms = [


### PR DESCRIPTION
Nix defaults to `xyce` (lowercase), which means `nix run .#xyce` doesn't work. (Thanks @mlyoung101)