### PR TITLE
Port KLayout to Qt6 (with Qt5 compat)

### DIFF
--- a/nix/klayout.nix
+++ b/nix/klayout.nix
@@ -24,7 +24,8 @@
   lib,
   clangStdenv,
   fetchFromGitHub,
-  libsForQt5,
+  qt6,
+  qt6Packages,
   which,
   perl,
   python3,
@@ -72,14 +73,14 @@ clangStdenv.mkDerivation {
     (python3.withPackages (ps: with ps; [ setuptools ]))
     ruby
     gnused
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
-  buildInputs = with libsForQt5; [
+  buildInputs = with qt6Packages; [
     qtbase
     qtmultimedia
     qttools
-    qtxmlpatterns
+    qt5compat
     curl
     gcc
     libgit2


### PR DESCRIPTION
This appears to resolve #75.

Upstream recommends Qt5, but also supports Qt6: https://www.klayout.de/build.html

> Qt: Qt4 >= 4.8.5 (Qt 5 preferred, Qt 6 supported).