### PR TITLE
feat: add gdsfill

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,7 @@
               ghdl-bin = callPackage ./nix/ghdl-bin.nix { };
 
               # Main collection
+              gdsfill = callPackage ./nix/gdsfill.nix { };
               kepler-formal = callPackage ./nix/kepler-formal.nix { };
               klayout = callPackage ./nix/klayout.nix { };
               klayout-app = pkgs'.klayout; # alias, there's a python package called klayout (related) (thats also this)
@@ -175,6 +176,7 @@
           bitwuzla = lib.warn "Starting nix-eda 8, packages.${system}.bitwuzla will be removed. For the Yosys-compatible version, use oss-cad-suite-bitwuzla." pkgs.oss-cad-suite-bitwuzla;
           inherit (pkgs)
             oss-cad-suite-bitwuzla
+            gdsfill
             ghdl-bin
             iverilog
             kepler-formal

--- a/nix/gdsfill.nix
+++ b/nix/gdsfill.nix
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 nix-eda Contributors
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  cmake,
+  version ? "0.1.8",
+  rev ? null,
+  sha256 ? "sha256-DG6QOB5MFRr+Rsr5wcrsQkSHYD9iubuA2LPcCGuAKpY=",
+}:
+rustPlatform.buildRustPackage {
+  pname = "gdsfill";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "aesc-silicon";
+    repo = "gdsfill";
+    tag = if rev == null then "v${version}" else rev;
+    hash = sha256;
+  };
+
+  cargoHash = "sha256-n4WJbeoH+M85Mv3sBeEpKdk+xv3fbL54PT0xlEV/voI=";
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Tool for inserting dummy metal fill into semiconductor layouts";
+    homepage = "https://github.com/aesc-silicon/gdsfill";
+    license = lib.licenses.lgpl21Plus;
+    mainProgram = "gdsfill";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
gdsfill is a Rust application to add metal dummy fill to GDSII files. It's optimized for speed while achieving the best density target per tile.

It currently supports IHP SG13G2 and SG13CMOS5L.