### PR TITLE
chore: fix deprecation warning

### DIFF
--- a/nix/ngspice.nix
+++ b/nix/ngspice.nix
@@ -28,7 +28,8 @@
   bison,
   fftw,
   withNgshared ? true,
-  xorg,
+  libxaw,
+  libxext,
   autoconf,
   automake,
   libtool,
@@ -56,8 +57,8 @@ clangStdenv.mkDerivation {
 
   buildInputs = [
     fftw
-    xorg.libXaw
-    xorg.libXext
+    libxaw
+    libxext
     readline
     llvmPackages.openmp
   ];


### PR DESCRIPTION
Resolves:

```
evaluation warning: The xorg package set has been deprecated, 'xorg.libXaw' has been renamed to 'libxaw'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXext' has been renamed to 'libxext'
```