### PR TITLE
init gtkwave at 3.3.128

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,16 +17,19 @@ We compile and cache the tools for the following platforms:
 | macOS (arm64) | `aarch64-darwin` |
 
 ## Tools Included
-* [Magic](http://opencircuitdesign.com/magic)
-* [Netgen](http://opencircuitdesign.com/netgen)
-* [ngspice](https://ngspice.sourceforge.io)
+* [cocotb](https://www.cocotb.org/)
+* [Kepler-Formal](https://github.com/keplertech/kepler-formal)
 * [KLayout](https://klayout.de)
     * (+ `.python3.pkgs.klayout` for Python module)
 * [GDSFactory](https://github.com/gdsfactory/gdsfactory)
     * (+ `klayout-gdsfactory` as a shorthand for an environment with both installed)
-* [Verilator](https://verilator.org)
+* [GTKWave](https://github.com/gtkwave/gtkwave) (LTS branch)
 * [Icarus Verilog](https://github.com/steveicarus/iverilog)
-* [cocotb](https://www.cocotb.org/)
+* [Magic](http://opencircuitdesign.com/magic)
+* [Netgen](http://opencircuitdesign.com/netgen)
+* [ngspice](https://ngspice.sourceforge.io)
+* [OpenVAF Reloaded](https://github.com/OpenVAF/OpenVAF-Reloaded)
+* [Verilator](https://verilator.org)
 * [Xschem](https://xschem.sourceforge.io/stefan/index.html)
 * [Xyce](https://github.com/xyce/xyce)
     * Linux only.
@@ -34,8 +37,6 @@ We compile and cache the tools for the following platforms:
     * (+ `python3.pkgs.pyosys` for Python module)
     * (+ some plugins that can be accessed programmatically)
     * (`yosysFull` for all plugins)
-* [Kepler-Formal](https://github.com/keplertech/kepler-formal)
-* [OpenVAF Reloaded](https://github.com/OpenVAF/OpenVAF-Reloaded)
 
 > [!NOTE]
 > As of the time of writing, if you're using KLayout and gdsfactory for sky130

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,7 @@
 
               # Main collection
               gdsfill = callPackage ./nix/gdsfill.nix { };
+              gtkwave = callPackage ./nix/gtkwave.nix { gtkwave = pkgs.gtkwave; };
               kepler-formal = callPackage ./nix/kepler-formal.nix { };
               klayout = callPackage ./nix/klayout.nix { };
               klayout-app = pkgs'.klayout; # alias, there's a python package called klayout (related) (thats also this)
@@ -178,6 +179,7 @@
           inherit (pkgs)
             gdsfill
             ghdl-bin
+            gtkwave
             iverilog
             kepler-formal
             klayout

--- a/nix/gtkwave.nix
+++ b/nix/gtkwave.nix
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 fossi-foundation/nix-eda contributors
+{
+  lib,
+  gtkwave,
+  fetchurl,
+  version ? "3.3.128",
+  sha256 ? "sha256-gX4Zf8GAj4qsNUPCwvloPLATaMkRkrjq5a9YBw7x0fg=",
+}:
+gtkwave.overrideAttrs (
+  attrs': attrs: {
+    inherit version;
+    src = fetchurl {
+      url = "mirror://sourceforge/gtkwave/gtkwave-gtk3-${attrs'.version}.tar.gz";
+      inherit sha256;
+    };
+
+    # disable judy because of bounds checking issue on newer
+    # platforms
+    configureFlags = (lib.strings.filter (x: x != "--enable-judy") attrs.configureFlags) ++ [
+      "--disable-judy"
+    ];
+  }
+)


### PR DESCRIPTION
By way of overlay from nix-eda. also disable judy because of a bounds-checking issue on macOS and Linux.