### PR TITLE
ci: fix nix_copy_s3 with lix 2.95 + other tweaks

### DIFF
--- a/.github/actions/install_nix/action.yml
+++ b/.github/actions/install_nix/action.yml
@@ -49,3 +49,7 @@ runs:
         sudo /usr/libexec/PlistBuddy -c "Add :EnvironmentVariables:GITHUB_TOKEN string ${{ inputs.github_token }}" /Library/LaunchDaemons/org.nixos.nix-daemon.plist
         sudo launchctl bootout system/org.nixos.nix-daemon
         sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+    - name: Print Diagnostic Info
+      shell: bash
+      run: |
+        nix-shell -p nix-info --run "nix-info -m"

--- a/.github/actions/nix_sign_cache_s3/action.yml
+++ b/.github/actions/nix_sign_cache_s3/action.yml
@@ -62,7 +62,10 @@ runs:
       shell: ${{ inputs.shell }}
       if: inputs.s3_bucket_name != '' && inputs.nix_public_key != '' && inputs.nix_private_key != '' && inputs.aws_region != '' && inputs.aws_access_key_id != '' && inputs.aws_secret_access_key != ''
       run: |
-        python3 ${{ github.action_path }}/nix_copy_s3.py \
+        TEMP_VENV=$(mktemp -d)
+        python3 -m venv $TEMP_VENV
+        $TEMP_VENV/bin/python3 -m pip install --upgrade httpx
+        $TEMP_VENV/bin/python3 ${{ github.action_path }}/nix_copy_s3.py \
           --upstream-cache "https://cache.nixos.org" \
           --upstream-cache "TARGET_HTTPS" \
           --to-s3-bucket "${{ inputs.s3_bucket_name }}" \

--- a/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
+++ b/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
@@ -127,8 +127,7 @@ def nix_pathinfo_parse(
         *(("--store", store) if store is not None else ()),
         *paths,
     ]
-    if os.getenv("VERBOSE", "0") == "1":
-        print(f"$ {shlex.join(cmd)}", file=sys.stderr)
+    logging.info(f"\t\t> {shlex.join(cmd)}")
     process = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
+++ b/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
@@ -75,13 +75,70 @@ def parse_narinfo(file: io.TextIOWrapper):
     return result
 
 
-def check_json_out(args: List[str], **kwargs):
-    if "encoding" not in kwargs:
-        kwargs["encoding"] = "utf8"
+class NixPathInfoError(RuntimeError):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    @classmethod
+    def from_stderr(Self, stderr: io.TextIOWrapper):
+        does_not_exist = re.compile(r"error: path '(\S+?)' does not exist in the store")
+        unavailable = re.compile(r"Refusing to evaluate package '(\S+?)'")
+
+        stderr_str = stderr.read()
+
+        for line in stderr_str.splitlines():
+            if dne_match := does_not_exist.search(line):
+                return NixPathNotFound(dne_match[1])
+            if unavailable_match := unavailable.search(line):
+                return NixDerivationUnavailable(unavailable_match[1])
+
+        return Self(f"unexpected error occurred:\n" + stderr_str)
+
+
+class NixDerivationUnavailable(NixPathInfoError):
+    def __init__(self, name):
+        self.name = name
+        super().__init__(
+            f"derivation '{self.name}' is not available on the requested hostPlatform"
+        )
+
+
+class NixPathNotFound(NixPathInfoError):
+    def __init__(self, path):
+        self.path = path
+        super().__init__(
+            f"path '{self.path}' not found in nix store, likely failed to build"
+        )
+
+
+def nix_pathinfo_parse(
+    *paths,
+    recursive=True,
+    encoding="utf8",
+    eval_store: str | None = None,
+    store: str | None = None,
+):
+    cmd = [
+        "nix",
+        "path-info",
+        "--json",
+        *(recursive * ("--recursive",)),
+        *(("--eval-store", eval_store) if eval_store is not None else ()),
+        *(("--store", store) if store is not None else ()),
+        *paths,
+    ]
     if os.getenv("VERBOSE", "0") == "1":
-        print(f"$ {shlex.join(args)}", file=sys.stderr)
-    out_str = subprocess.check_output(args, **kwargs)
-    return json.loads(out_str)
+        print(f"$ {shlex.join(cmd)}", file=sys.stderr)
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding=encoding,
+    )
+    process.wait()
+    if process.returncode:
+        raise NixPathInfoError.from_stderr(process.stderr)
+    return json.load(process.stdout)
 
 
 def paths_from_path_info(path_info_raw: Any):
@@ -143,23 +200,10 @@ def main(text_args):
 
         # 0. List all paths that this flake output depends on, the "closure"
         try:
-            closure_raw: Any = check_json_out(
-                ["nix", "path-info", "--recursive", "--json", flake_output],
-                stderr=subprocess.PIPE,
-            )
-        except subprocess.CalledProcessError as e:
-            if "is not valid" in e.stderr:
-                logging.warning(
-                    f"Failed to get store paths for {flake_output} -- assuming broken, skipping…"
-                )
-                continue
-            elif "does not exist in the store" in e.stderr:
-                logging.warning(
-                    f"{flake_output} does not exist in the store, possibly unbuilt. Skipping…"
-                )
-                continue
-            else:
-                raise e from None
+            closure_raw = nix_pathinfo_parse(flake_output)
+        except (NixPathNotFound, NixDerivationUnavailable) as e:
+            logging.warning(f"Skipping {flake_output}: {e}")
+            continue
 
         closure = paths_from_path_info(closure_raw)
         if closure is None:
@@ -176,18 +220,10 @@ def main(text_args):
         if len(paths_to_query):
             logging.info("Checking for paths upstream…")
             for cache in upstream_caches:
-                upstream_cache_info_raw = check_json_out(
-                    [
-                        "nix",
-                        "path-info",
-                        "--json",
-                        "--eval-store",
-                        "",
-                        "--store",
-                        cache,
-                        *paths_to_query,
-                    ],
-                    stderr=subprocess.PIPE,
+                upstream_cache_info_raw = nix_pathinfo_parse(
+                    *paths_to_query,
+                    eval_store="",
+                    store=cache,
                 )
                 upstream_cache_paths = paths_from_path_info(upstream_cache_info_raw)
                 if upstream_cache_paths is None:

--- a/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
+++ b/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
@@ -29,9 +29,12 @@ https://cachix.nixos.org: See https://github.com/NixOS/nix/issues/13333.
 
 This script is intended as a stop-gap measure until this is implemented.
 
-This script requires Python 3.8+ and the AWS CLI to be installed (with
-credentials configured in the environment.)
+This script requires:
+- Python 3.8+ with httpx
+- the AWS CLI to be installed (with credentials configured in the environment.)
 """
+import httpx
+
 import io
 import os
 import re
@@ -44,8 +47,6 @@ import subprocess
 import logging
 from pathlib import Path
 from urllib.parse import urlparse
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 from typing import Any, List, Dict, Set
 
 ws_rx = re.compile(r"\s+")
@@ -55,7 +56,7 @@ logging.basicConfig(
     level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 def parse_narinfo(file: io.TextIOWrapper):
     result: Dict[str, Any] = {}
@@ -83,19 +84,17 @@ class NixPathInfoError(RuntimeError):
         super().__init__(*args)
 
     @classmethod
-    def from_stderr(Self, stderr: io.TextIOWrapper):
+    def from_stderr(Self, stderr: str):
         does_not_exist = re.compile(r"error: path '(\S+?)' does not exist in the store")
         unavailable = re.compile(r"Refusing to evaluate package '(\S+?)'")
 
-        stderr_str = stderr.read()
-
-        for line in stderr_str.splitlines():
+        for line in stderr.splitlines():
             if dne_match := does_not_exist.search(line):
                 return NixPathNotFound(dne_match[1])
             if unavailable_match := unavailable.search(line):
                 return NixDerivationUnavailable(unavailable_match[1])
 
-        return Self(f"unexpected error occurred:\n" + stderr_str)
+        return Self(f"unexpected error occurred:\n" + stderr)
 
 
 class NixDerivationUnavailable(NixPathInfoError):
@@ -137,10 +136,10 @@ def nix_pathinfo_parse(
         stderr=subprocess.PIPE,
         encoding=encoding,
     )
-    process.wait()
-    if process.returncode:
-        raise NixPathInfoError.from_stderr(process.stderr)
-    return json.load(process.stdout)
+    stdout, stderr = process.communicate()
+    if process.returncode != 0:
+        raise NixPathInfoError.from_stderr(stderr)
+    return json.loads(stdout)
 
 
 def paths_from_path_info(path_info_raw: Any):
@@ -159,20 +158,17 @@ def filter_store_paths_by_remote(
     remote="https://cache.nixos.org"
 ):
     remote = remote.rstrip("/")
-    in_remote = []
+    filtered = []
+    client = httpx.Client()
     for path in store_paths:
         p = Path(path)
         name = p.name
         hash, _ = name.split("-", maxsplit=1)
         narinfo_path = f"{remote}/{hash}.narinfo"
-        req = Request(narinfo_path)
-        try:
-            with urlopen(req) as res:
-                if (res.getcode() // 100) == 2:
-                    in_remote.append(path)
-        except HTTPError:
-            continue
-    return in_remote
+        res = client.request("HEAD", narinfo_path)
+        if (res.status_code // 100) == 2:
+            filtered.append(path)
+    return filtered
 
 
 def main(text_args):

--- a/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
+++ b/.github/actions/nix_sign_cache_s3/nix_copy_s3.py
@@ -42,8 +42,11 @@ import sys
 import tempfile
 import subprocess
 import logging
-from typing import Any, List, Dict, Set
+from pathlib import Path
 from urllib.parse import urlparse
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+from typing import Any, List, Dict, Set
 
 ws_rx = re.compile(r"\s+")
 
@@ -151,6 +154,26 @@ def paths_from_path_info(path_info_raw: Any):
         )
         return None
 
+def filter_store_paths_by_remote(
+    *store_paths,
+    remote="https://cache.nixos.org"
+):
+    remote = remote.rstrip("/")
+    in_remote = []
+    for path in store_paths:
+        p = Path(path)
+        name = p.name
+        hash, _ = name.split("-", maxsplit=1)
+        narinfo_path = f"{remote}/{hash}.narinfo"
+        req = Request(narinfo_path)
+        try:
+            with urlopen(req) as res:
+                if (res.getcode() // 100) == 2:
+                    in_remote.append(path)
+        except HTTPError:
+            continue
+    return in_remote
+
 
 def main(text_args):
     args = argparse.ArgumentParser()
@@ -219,15 +242,10 @@ def main(text_args):
         if len(paths_to_query):
             logging.info("Checking for paths upstream…")
             for cache in upstream_caches:
-                upstream_cache_info_raw = nix_pathinfo_parse(
+                upstream_cache_paths = filter_store_paths_by_remote(
                     *paths_to_query,
-                    eval_store="",
-                    store=cache,
+                    remote=cache,
                 )
-                upstream_cache_paths = paths_from_path_info(upstream_cache_info_raw)
-                if upstream_cache_paths is None:
-                    continue
-
                 paths_in_upstream_caches.update(
                     {path: cache for path in upstream_cache_paths}
                 )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
               nix_double: "x86_64-linux",
             },
             {
-              name: "Ubuntu 22.04",
+              name: "Ubuntu 24.04",
               family: "linux",
-              runner: "ubuntu-22.04-arm",
+              runner: "ubuntu-24.04-arm",
               archs: "aarch64",
               nix_double: "aarch64-linux",
             },
@@ -41,7 +41,7 @@ jobs:
     name: Nix Builds | ${{ matrix.os.name }} | ${{ matrix.os.archs }}
     runs-on: ${{ matrix.os.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Nix (+ add GitHub Token to Environment)
         uses: ./.github/actions/install_nix
         with:


### PR DESCRIPTION

- nix_copy_s3:
  - better handling of errors from nix_pathinfo_parse
  - new function `filter_store_paths_by_remote` to replace cringe use of `nix path-info` that was removed in https://git.lix.systems/lix-project/lix/commit/7d764670c82308f061027a7e5beacfb9c17273bb
- misc ci updates:
  - .github/actions/install_nix/action.yml: Print nix diagnostic info after setup
  - ubuntu-22.04-arm -> ubuntu-24.04-arm
  - bump checkout action version