### PR TITLE
chore: update yosys to 0.68

### DIFF
--- a/.github/workflows/get_all_packages.py
+++ b/.github/workflows/get_all_packages.py
@@ -13,7 +13,7 @@ def run(purpose, *args):
     process.wait()
     if process.returncode:
         stderr = process.stderr.read()
-        if "marked as broken" in stderr:
+        if "marked as broken" in stderr or "This package is broken" in stderr:
             print(
                 f"Warning: failed to {purpose} (one or more dependencies marked as broken on current hostPlatform)",
                 file=sys.stderr,

--- a/flake.nix
+++ b/flake.nix
@@ -171,7 +171,6 @@
             [
               yosys-sby
               yosys-eqy
-              yosys-slang
             ]
             ++ lib.optionals (lib.meta.availableOn pkgs.stdenv.hostPlatform yosys-ghdl) [ yosys-ghdl ]
           );
@@ -196,7 +195,6 @@
             yosys
             yosys-sby
             yosys-eqy
-            yosys-slang
             yosys-ghdl
             ;
           inherit (pkgs.python3.pkgs)

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,9 @@
               yosys = callPackage ./nix/yosys.nix { };
               yosys-sby = callPackage ./nix/yosys-sby.nix { };
               yosys-eqy = callPackage ./nix/yosys-eqy.nix { };
-              yosys-slang = callPackage ./nix/yosys-slang.nix { };
+              yosys-slang =
+                lib.warn "yosys-slang will be removed starting nix-eda 8.0.0 as slang is now built into Yosys."
+                  (callPackage ./nix/yosys-slang.nix { });
               yosys-ghdl = callPackage ./nix/yosys-ghdl.nix {
                 ghdl' =
                   if (lib.meta.availableOn pkgs'.stdenv.hostPlatform pkgs'.ghdl-bin) then
@@ -193,9 +195,10 @@
             xschem
             xyce
             yosys
-            yosys-sby
             yosys-eqy
             yosys-ghdl
+            yosys-slang
+            yosys-sby
             ;
           inherit (pkgs.python3.pkgs)
             cocotb

--- a/nix/yosys-eqy.nix
+++ b/nix/yosys-eqy.nix
@@ -25,12 +25,12 @@
   yosys,
   libedit,
   libbsd,
-  oss-cad-suite-bitwuzla,
+  bitwuzla,
   zlib,
   yosys-sby,
   makeBinaryWrapper,
-  version ? "0.66",
-  sha256 ? "sha256-a2wc0OCVyl7N01g9MV3rnSay5c0jy8YCDB0d4eCNTr4=",
+  version ? "0.68",
+  sha256 ? "sha256-9N5hztnCziHiIt7fEjTiM3lWZy27TkHCLxqmfQzQiwg=",
 }:
 yosys.stdenv.mkDerivation (finalAttrs: {
   pname = "yosys-eqy";
@@ -61,7 +61,7 @@ yosys.stdenv.mkDerivation (finalAttrs: {
     yosys
     libedit
     libbsd
-    oss-cad-suite-bitwuzla
+    bitwuzla
     zlib
     yosys-sby
     yosys.python3-env

--- a/nix/yosys-sby.nix
+++ b/nix/yosys-sby.nix
@@ -27,8 +27,8 @@
   boolector,
   z3,
   yices,
-  version ? "0.66",
-  sha256 ? "sha256-SrnapPqQ/bAcTbuvc/P+OuFqiPKtUIPqykzEU6d4VE4=",
+  version ? "0.68",
+  sha256 ? "sha256-WRZp4+gwUgDKCWAdBK/36ArM2KFGyLBZ20S32k7YN+8=",
 }:
 yosys.stdenv.mkDerivation (finalAttrs: {
   pname = "yosys-sby";
@@ -66,9 +66,10 @@ yosys.stdenv.mkDerivation (finalAttrs: {
     runHook postPatch
   '';
 
-  doCheck = false; # it just takes forever man
   checkPhase = ''
+    runHook preCheck
     make test SBY_MAIN=$src/sbysrc/sby.py
+    runHook postCheck
   '';
 
   makeWrapperArgs = [

--- a/nix/yosys-slang.nix
+++ b/nix/yosys-slang.nix
@@ -24,11 +24,13 @@
   clangStdenv,
   fetchGitHubSnapshot,
   cmake,
-  fmt,
   jq,
-  rev ? "35de04061a71c6260f5879ae13855937baad58e1",
-  rev-date ? "2026-05-30",
-  hash ? "sha256-JvWzdfPVQ6FqwrpWgd2zLB4X77JFajMr7zfPnEkoARc=",
+  fmt,
+  boost,
+  tomlplusplus,
+  rev ? "e2829839afc62961d704123f30ed46e75477f33c",
+  rev-date ? "2026-08-03",
+  hash ? "sha256-ovLFi/1p9fOzWD6dEkhSO8SHcLfjOmBLqax5zB2JXHk=",
 }:
 clangStdenv.mkDerivation {
   name = "yosys-slang";
@@ -37,22 +39,27 @@ clangStdenv.mkDerivation {
 
   src = fetchGitHubSnapshot {
     owner = "povik";
-    repo = "yosys-slang";
+    repo = "sv-elab";
     inherit rev;
     inherit hash;
   };
 
   cmakeFlags = [
     "-DYOSYS_CONFIG=${yosys}/bin/yosys-config"
+    "-DSLANG_USE_SYSTEM_BOOST:BOOL=ON"
     "-DFMT_INSTALL:BOOL=OFF"
   ];
 
   nativeBuildInputs = [
     cmake
     jq
-  ]; # ninja doesn't work, cba to debug why
+    # ninja is broken and idk why
+  ];
+
   buildInputs = [
     yosys
+    boost
+    tomlplusplus
     yosys.python3-env
     fmt
   ];
@@ -67,9 +74,6 @@ clangStdenv.mkDerivation {
   '';
 
   doCheck = true;
-
-  # Release, at least in Nix, is broken. Can't figure out why entirely.
-  cmakeBuildType = "Debug";
 
   installPhase = ''
     runHook preBuild

--- a/nix/yosys-slang.nix
+++ b/nix/yosys-slang.nix
@@ -88,5 +88,6 @@ clangStdenv.mkDerivation {
     license = [ lib.licenses.mit ];
     homepage = "https://github.com/povik/yosys-slang";
     platforms = lib.platforms.all;
+    badPlatforms = [ "aarch64-linux" ];
   };
 }

--- a/nix/yosys.nix
+++ b/nix/yosys.nix
@@ -39,9 +39,9 @@
   cmake,
   ninja,
   bash,
-  version ? "0.67",
+  version ? "0.68",
   rev ? null,
-  sha256 ? "sha256-qi1YXob6xlS8NMEYEPxG6Z0mP3CUzD9pMCCq7xmnoqE=",
+  sha256 ? "sha256-U4mBg5oT9jNvDdrmDPf0sm2jEzWpCaC5D5qR7Henq3Q=",
   darwin, # To fix codesigning issue for pyosys
   # For environments
   yosys,
@@ -78,6 +78,37 @@ let
       rev = if rev == null then "v${version}" else "rev";
       hash = sha256;
     };
+
+    postPatch = ''
+      # in local (nix develop .#yosys) builds, the brew code takes priority for
+      # some reason, better safe than sorry
+      printf "function(use_homebrew)\nendfunction()\n" > cmake/UseHomebrew.cmake
+
+      # default version code does way too much and I prefer +g<shortrev>
+      # verisoning
+      substituteInPlace cmake/YosysVersion.cmake \
+        --replace-fail "yosys_extract_version" "yosys_extract_version_bk"
+      cat <<'EOF' >> ./cmake/YosysVersion.cmake
+      function(yosys_extract_version)
+        include(YosysVersionData)
+        set(YOSYS_VERSION_COMMIT "0")
+        set(YOSYS_VERSION "${finalAttrs.version}${
+          if rev == null then "" else "+g${lib.sources.shortRev rev}"
+        }")
+        file(READ "''${CMAKE_SOURCE_DIR}/.gitcommit" YOSYS_CHECKOUT_INFO)
+        string(STRIP "''${YOSYS_CHECKOUT_INFO}" YOSYS_CHECKOUT_INFO)
+        set(YOSYS_ORIGIN_INFO "")
+        return(PROPAGATE
+          YOSYS_VERSION_MAJOR
+          YOSYS_VERSION_MINOR
+          YOSYS_VERSION_COMMIT
+          YOSYS_VERSION
+          YOSYS_CHECKOUT_INFO
+          YOSYS_ORIGIN_INFO
+        )
+      endfunction()
+      EOF
+    '';
 
     nativeBuildInputs = [
       pkg-config
@@ -150,6 +181,8 @@ let
       "-DYOSYS_WITH_PYTHON:BOOL=ON"
       "-DYOSYS_INSTALL_PYTHON:BOOL=ON"
       "-DYOSYS_INSTALL_PYTHON_SITEDIR=${builtins.placeholder "python"}"
+      # tends to malfunction when you don't have git installed
+      "-DYOSYS_SKIP_ABC_SUBMODULE_CHECK:BOOL=ON"
     ];
 
     doCheck = false;

--- a/nix/yosys.nix
+++ b/nix/yosys.nix
@@ -36,10 +36,12 @@
   zlib,
   fetchurl,
   fetchGitHubSnapshot,
+  cmake,
+  ninja,
   bash,
-  version ? "0.66",
+  version ? "0.67",
   rev ? null,
-  sha256 ? "sha256-wuufUmGe5+7urSK2Px647yx2GPIpjJOKZROBvHanDE0=",
+  sha256 ? "sha256-qi1YXob6xlS8NMEYEPxG6Z0mP3CUzD9pMCCq7xmnoqE=",
   darwin, # To fix codesigning issue for pyosys
   # For environments
   yosys,
@@ -55,6 +57,7 @@ let
       click
       setuptools
       wheel
+      build
     ]
   );
   site-packages = yosys-python3-env.sitePackages;
@@ -80,6 +83,8 @@ let
       pkg-config
       bison
       flex
+      cmake
+      ninja
     ]
     ++ lib.optionals clangStdenv.isDarwin [ darwin.autoSignDarwinBinariesHook ];
 
@@ -141,29 +146,13 @@ let
       };
     };
 
-    configurePhase = ''
-      runHook preConfigure
-      CC=clang CXX=clang++ make config-clang
-      runHook postConfigure
-    '';
-
-    makeFlags = [
-      "PRETTY=0"
-      "PREFIX=${placeholder "out"}"
-      "ENABLE_READLINE=0"
-      "ENABLE_EDITLINE=1"
-      "ENABLE_YOSYS=1"
-      "ENABLE_PYOSYS=1"
-      "PYTHON_DESTDIR=${placeholder "python"}/${site-packages}"
-      "PYOSYS_USE_UV=0"
+    cmakeFlags = [
+      "-DYOSYS_WITH_PYTHON:BOOL=ON"
+      "-DYOSYS_INSTALL_PYTHON:BOOL=ON"
+      "-DYOSYS_INSTALL_PYTHON_SITEDIR=${builtins.placeholder "python"}"
     ];
 
-    postInstall = ''
-      python3 ./setup.py dist_info -o $python/${site-packages}
-    '';
-
     doCheck = false;
-    enableParallelBuilding = true;
 
     meta = {
       description = "Yosys Open SYnthesis Suite";


### PR DESCRIPTION
- yosys, yosys-sby, yosys-eqy -> 0.68 + update CMake versioning code to correctly extract correct commits and whatnot
- yosys-slang updated to 2026-08-03 but removed from default plugin set (yosys now vendors it)
  - Marked yosys-slang broken on aarch64-linux
- .github/workflows/get_all_packages.py: don't abort on new broken package error message